### PR TITLE
[fix] add script dir to sys.path for lib module imports

### DIFF
--- a/.ai/scripts/audit_project.py
+++ b/.ai/scripts/audit_project.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
 import sys
+import os
 import json
 import subprocess
 import time
 from pathlib import Path
+
+# Add scripts directory to Python path for lib imports
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
+
 from lib.errors import AWKError, ConfigError, handle_unexpected_error, print_error
 from lib.logger import Logger, split_log_level
 

--- a/.ai/scripts/parse_tasks.py
+++ b/.ai/scripts/parse_tasks.py
@@ -20,10 +20,16 @@ Dependency syntax in tasks.md:
 
 import re
 import sys
+import os
 import json
 from pathlib import Path
 from collections import defaultdict
 from typing import Dict, List, Set, Tuple, Optional
+
+# Add scripts directory to Python path for lib imports
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
 
 from lib.errors import AWKError, ConfigError, handle_unexpected_error, print_error
 from lib.logger import Logger, split_log_level

--- a/.ai/scripts/query_traces.py
+++ b/.ai/scripts/query_traces.py
@@ -8,8 +8,14 @@ Usage:
 import argparse
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any, Dict, List
+
+# Add scripts directory to Python path for lib imports
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
 
 from lib.errors import AWKError, ConfigError, handle_unexpected_error, print_error
 from lib.logger import Logger, normalize_level

--- a/.ai/scripts/scan_repo.py
+++ b/.ai/scripts/scan_repo.py
@@ -16,6 +16,11 @@ import re
 import time
 from pathlib import Path
 
+# Add scripts directory to Python path for lib imports
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
+
 from lib.errors import AWKError, ConfigError, handle_unexpected_error, print_error
 from lib.logger import Logger, split_log_level
 

--- a/.ai/scripts/validate_config.py
+++ b/.ai/scripts/validate_config.py
@@ -7,6 +7,11 @@ import sys
 import os
 import json
 
+# Add scripts directory to Python path for lib imports
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
+
 from lib.errors import AWKError, ConfigError, ValidationError, handle_unexpected_error, print_error
 from lib.logger import Logger, split_log_level
 


### PR DESCRIPTION
Python scripts failed with "ModuleNotFoundError: No module named 'lib'" when executed from project root with relative path (e.g., python3 .ai/scripts/validate_config.py). Fixed by explicitly adding SCRIPT_DIR to sys.path before importing lib modules.

Affected files:
- .ai/scripts/validate_config.py
- .ai/scripts/scan_repo.py
- .ai/scripts/query_traces.py
- .ai/scripts/parse_tasks.py
- .ai/scripts/audit_project.py

Added test to cover this scenario.