### PR TITLE
[fix] prevent preset config from being overwritten by copyDir

### DIFF
--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -146,10 +146,14 @@ curl -fsSL https://github.com/silver2dream/ai-workflow-kit/releases/latest/downl
 更新專案內的 kit 檔案：
 
 ```bash
+# 只更新 kit 檔案（保留你的 workflow.yaml）
 awkit init --force
 
-# 或指定路徑
-awkit init /path/to/your-project --force
+# 只套用不同的 preset 到 workflow.yaml
+awkit init --preset react-go --force-config
+
+# 完整重置：更新 kit 檔案並套用 preset 到 workflow.yaml
+awkit init --preset react-go --force
 ```
 
 ### 1) 安裝 offline 依賴

--- a/README.md
+++ b/README.md
@@ -146,10 +146,14 @@ curl -fsSL https://github.com/silver2dream/ai-workflow-kit/releases/latest/downl
 Update kit files inside a project:
 
 ```bash
+# Update kit files only (keeps your workflow.yaml)
 awkit init --force
 
-# Or specify a path
-awkit init /path/to/your-project --force
+# Apply a different preset to workflow.yaml only
+awkit init --preset react-go --force-config
+
+# Full reset: update kit files AND apply preset to workflow.yaml
+awkit init --preset react-go --force
 ```
 
 ### 1) Install offline dependencies

--- a/cmd/awkit/main.go
+++ b/cmd/awkit/main.go
@@ -343,9 +343,20 @@ func cmdInit(args []string) int {
 		fmt.Println("Would create/update:")
 		fmt.Println("  .ai/config/workflow.yaml")
 		fmt.Println("  .ai/scripts/")
+		fmt.Println("  .ai/scripts/lib/")
 		fmt.Println("  .ai/templates/")
 		fmt.Println("  .ai/rules/")
 		fmt.Println("  .ai/commands/")
+		fmt.Println("  .ai/docs/")
+		fmt.Println("  .ai/tests/")
+		fmt.Println("  .ai/specs/")
+		fmt.Println("  .ai/state/ (runtime, gitignored)")
+		fmt.Println("  .ai/results/ (runtime, gitignored)")
+		fmt.Println("  .ai/runs/ (runtime, gitignored)")
+		fmt.Println("  .ai/exe-logs/ (runtime, gitignored)")
+		fmt.Println("  .worktrees/ (gitignored)")
+		fmt.Println("  .claude/rules -> .ai/rules (symlink)")
+		fmt.Println("  .claude/commands -> .ai/commands (symlink)")
 		if *withCI {
 			fmt.Println("  .github/workflows/ci.yml (if missing)")
 		}
@@ -547,7 +558,7 @@ _awkit() {
             return 0
             ;;
         init|install)
-            local opts="--preset --force --dry-run --no-generate --with-ci --project-name --help"
+            local opts="--preset --force --force-config --dry-run --no-generate --with-ci --project-name --help"
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) $(compgen -d -- ${cur}) )
             return 0
             ;;
@@ -604,7 +615,8 @@ _awkit() {
                 init|install)
                     _arguments \
                         '--preset[Project preset]:preset:(generic react-go)' \
-                        '--force[Overwrite existing files]' \
+                        '--force[Overwrite all existing files]' \
+                        '--force-config[Overwrite only workflow.yaml]' \
                         '--dry-run[Show what would be done]' \
                         '--no-generate[Skip generate.sh]' \
                         '--with-ci[Create CI workflow]' \
@@ -646,7 +658,8 @@ complete -c awkit -n __fish_use_subcommand -a help -d 'Show help'
 
 # init/install options
 complete -c awkit -n '__fish_seen_subcommand_from init install' -l preset -d 'Project preset' -xa 'generic react-go'
-complete -c awkit -n '__fish_seen_subcommand_from init install' -l force -d 'Overwrite existing files'
+complete -c awkit -n '__fish_seen_subcommand_from init install' -l force -d 'Overwrite all existing files'
+complete -c awkit -n '__fish_seen_subcommand_from init install' -l force-config -d 'Overwrite only workflow.yaml'
 complete -c awkit -n '__fish_seen_subcommand_from init install' -l dry-run -d 'Show what would be done'
 complete -c awkit -n '__fish_seen_subcommand_from init install' -l no-generate -d 'Skip generate.sh'
 complete -c awkit -n '__fish_seen_subcommand_from init install' -l with-ci -d 'Create CI workflow'

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -104,6 +104,12 @@ func copyDir(src fs.FS, srcDir, dstDir string, force bool) error {
 			return os.MkdirAll(dstPath, 0o755)
 		}
 
+		// Skip workflow.yaml - it's managed by applyPreset, not copyDir
+		// This prevents the embedded default config from overwriting preset-generated config
+		if strings.HasSuffix(path, "workflow.yaml") {
+			return nil
+		}
+
 		if !force {
 			if _, err := os.Stat(dstPath); err == nil {
 				return nil

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -3,6 +3,7 @@ package install
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 )
@@ -189,5 +190,56 @@ func TestInstall_ForceConfig(t *testing.T) {
 	content, _ := os.ReadFile(filepath.Join(configDir, "workflow.yaml"))
 	if string(content) == "existing: true" {
 		t.Error("workflow.yaml was not overwritten with --force-config")
+	}
+}
+
+func TestInstall_PresetConfigNotOverwrittenByCopyDir(t *testing.T) {
+	// This test ensures that when using a preset (e.g., react-go),
+	// the preset's workflow.yaml is NOT overwritten by copyDir
+	// which copies the embedded default workflow.yaml.
+	tmpDir, err := os.MkdirTemp("", "awkit-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create a mock FS that includes a default workflow.yaml
+	// (simulating the embedded kit files with a different config)
+	mockFS := fstest.MapFS{
+		".ai/config/workflow.yaml":              &fstest.MapFile{Data: []byte("language: unity\n")},
+		".ai/config/workflow.schema.json":       &fstest.MapFile{Data: []byte(`{}`)},
+		".ai/scripts/generate.sh":               &fstest.MapFile{Data: []byte("#!/bin/bash\necho test")},
+		".ai/rules/.gitkeep":                    &fstest.MapFile{Data: []byte("")},
+		".ai/rules/_examples/backend-go.md":     &fstest.MapFile{Data: []byte("# Go rules")},
+		".ai/rules/_examples/frontend-react.md": &fstest.MapFile{Data: []byte("# React rules")},
+		".ai/commands/.gitkeep":                 &fstest.MapFile{Data: []byte("")},
+		".ai/templates/.gitkeep":                &fstest.MapFile{Data: []byte("")},
+	}
+
+	// Install with react-go preset and force mode
+	result, err := Install(mockFS, tmpDir, Options{
+		Preset:     "react-go",
+		Force:      true,
+		NoGenerate: true,
+	})
+	if err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Install returned nil result")
+	}
+
+	// Read the resulting workflow.yaml
+	content, err := os.ReadFile(filepath.Join(tmpDir, ".ai", "config", "workflow.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read workflow.yaml: %v", err)
+	}
+
+	// It should contain "typescript" (from react-go preset), NOT "unity" (from embedded default)
+	if strings.Contains(string(content), "language: unity") {
+		t.Error("workflow.yaml was overwritten by copyDir - should preserve preset config")
+	}
+	if !strings.Contains(string(content), "language: typescript") && !strings.Contains(string(content), "language: go") {
+		t.Error("workflow.yaml should contain react-go preset languages (typescript/go)")
 	}
 }


### PR DESCRIPTION
- Skip workflow.yaml in copyDir (managed by applyPreset)
- Add --force-config to shell completion scripts
- Update dry-run output to show all created directories
- Document --force vs --force-config in README