### PR TITLE
[fix] verify.setup: run before AI worker + diagnostic logging

### DIFF
--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -750,24 +750,6 @@ func RunIssue(ctx context.Context, opts RunIssueOptions) (*RunIssueResult, error
 		trace.StepStart("run_tests")
 	}
 
-	// Run setup command (dependency install) before verification
-	setupCmd := getSetupCommand(cfg, repoName)
-	if setupCmd != "" {
-		logger.Log("執行驗證前置設定...")
-		logger.Log("  運行: %s", setupCmd)
-		if setupErr := runVerificationCommand(ctx, workDir, setupCmd, opts.GitTimeout); setupErr != nil {
-			runErr = fmt.Errorf("verification setup failed: %s: %w", setupCmd, setupErr)
-			result.Error = runErr.Error()
-			result.Status = "failed"
-			if trace != nil {
-				_ = trace.StepEnd("failed", fmt.Sprintf("setup failed: %s: %v", setupCmd, setupErr), nil)
-			}
-			logger.Log("  ✗ 設定失敗: %v", setupErr)
-			return result, runErr
-		}
-		logger.Log("  ✓ 設定完成")
-	}
-
 	// Try to get verification commands from ticket first, fallback to config
 	verifyCommands := GetVerificationCommandsForRepo(string(ticketBody), repoName)
 	if len(verifyCommands) == 0 {


### PR DESCRIPTION
## Summary
- **Move `verify.setup` before Codex execution**: Setup (dependency install) was placed after Codex, but the AI worker runs verification commands internally via the prompt. Worktrees lack `node_modules/`, so `tsc` was not found and Codex failed before setup ever ran.
- **Add diagnostic logging**: Worker log was too sparse to diagnose failures — 15-minute gaps with no context. Now logs config path, repo name, attempt number, setup command, AI worker start/end with duration and exit code.
- **Remove debug stderr code**: Clean up `fmt.Fprintf(os.Stderr, "[setup-debug]...")` calls from `getSetupCommand()`.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/worker/` passes (including `TestGetSetupCommand` and `TestInferSetupCommand`)
- [ ] Rebuild `awkit`, run `awkit kickoff` on snake-arena, confirm Issue #56 (frontend) passes with `npm ci` before Codex
- [ ] Verify `.ai/exe-logs/issue-56.worker.log` shows full diagnostic output

🤖 Generated with [Claude Code](https://claude.com/claude-code)