### PR TITLE
[feat] expand unified event tracing coverage

### DIFF
--- a/cmd/awkit/events.go
+++ b/cmd/awkit/events.go
@@ -18,19 +18,24 @@ Usage:
 
 Options:
   --session <id>    Query specific session (default: current session)
+  --all             Query all sessions (not just current)
   --level <level>   Filter by level: info, warn, error, decision
-  --issue <n>       Filter by issue number
+  --issue <n>       Filter by issue number (searches across all sessions)
   --pr <n>          Filter by PR number
-  --component <c>   Filter by component: principal, worker, reviewer, github
+  --component <c>   Filter by component: principal, worker, reviewer, github, hooks, audit
+  --type <t>        Filter by event type (comma-separated, e.g. hook_fired,worker_retry)
   --last <n>        Show only last N events (default: all)
   --json            Output raw JSON (for AI analysis)
   --list            List available sessions
 
 Examples:
   awkit events                              # Show current session events
+  awkit events --all                        # Show events from all sessions
   awkit events --level decision             # Show only decision points
   awkit events --level error                # Show only errors
   awkit events --issue 25                   # Show events for issue #25
+  awkit events --type hook_fired,hook_failed  # Show only hook events
+  awkit events --type worker_retry          # Show worker retries
   awkit events --last 50                    # Show last 50 events
   awkit events --session principal-xxx      # Query specific session
   awkit events --list                       # List available sessions
@@ -44,10 +49,12 @@ func cmdEvents(args []string) int {
 	fs.Usage = usageEvents
 
 	sessionID := fs.String("session", "", "")
+	allSessions := fs.Bool("all", false, "")
 	level := fs.String("level", "", "")
 	issueNum := fs.Int("issue", 0, "")
 	prNum := fs.Int("pr", 0, "")
 	component := fs.String("component", "", "")
+	eventType := fs.String("type", "", "")
 	last := fs.Int("last", 0, "")
 	jsonOutput := fs.Bool("json", false, "")
 	listSessions := fs.Bool("list", false, "")
@@ -92,13 +99,21 @@ func cmdEvents(args []string) int {
 		Last:      *last,
 	}
 
+	// Parse --type flag (comma-separated)
+	if *eventType != "" {
+		filter.Types = strings.Split(*eventType, ",")
+	}
+
 	// Read events
 	var events []trace.Event
 	var err error
 
-	if *sessionID != "" {
+	switch {
+	case *sessionID != "":
 		events, err = reader.ReadSessionFiltered(*sessionID, filter)
-	} else {
+	case *allSessions || *issueNum > 0:
+		events, err = reader.ReadAllSessionsFiltered(filter)
+	default:
 		events, err = reader.ReadCurrentSessionFiltered(filter)
 	}
 
@@ -191,6 +206,10 @@ func colorizeComponent(component string) string {
 		return "\033[33mreviewer\033[0m"
 	case "github":
 		return "\033[35mgithub\033[0m"
+	case "hooks":
+		return "\033[90mhooks\033[0m"
+	case "audit":
+		return "\033[36;1maudit\033[0m"
 	default:
 		return component
 	}

--- a/internal/epicaudit/audit.go
+++ b/internal/epicaudit/audit.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/silver2dream/ai-workflow-kit/internal/analyzer"
+	"github.com/silver2dream/ai-workflow-kit/internal/trace"
 )
 
 // AuditOptions holds options for running an epic audit.
@@ -71,6 +72,13 @@ func RunAudit(ctx context.Context, opts AuditOptions, ghClient analyzer.GitHubCl
 	if epicIssue == 0 {
 		return nil, fmt.Errorf("no epic issue configured for spec %q", opts.SpecName)
 	}
+
+	// Emit audit_triggered trace event
+	trace.WriteEvent(trace.ComponentAudit, trace.TypeAuditTriggered, trace.LevelInfo,
+		trace.WithData(map[string]any{
+			"spec":       opts.SpecName,
+			"epic_issue": epicIssue,
+		}))
 
 	report := &AuditReport{
 		SpecName:  opts.SpecName,

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/silver2dream/ai-workflow-kit/internal/analyzer"
+	"github.com/silver2dream/ai-workflow-kit/internal/trace"
 )
 
 // HookRunner executes lifecycle hooks.
@@ -42,6 +43,17 @@ func (r *HookRunner) Fire(ctx context.Context, event string, envVars map[string]
 			if policy == "" {
 				policy = "warn"
 			}
+
+			// Emit hook_failed trace event
+			trace.WriteEvent(trace.ComponentHooks, trace.TypeHookFailed, trace.LevelWarn,
+				trace.WithData(map[string]any{
+					"event":   event,
+					"index":   i,
+					"command": h.Command,
+					"policy":  policy,
+				}),
+				trace.WithErrorString(err.Error()))
+
 			switch policy {
 			case "abort":
 				return fmt.Errorf("hook %s[%d] aborted: %w", event, i, err)
@@ -52,6 +64,14 @@ func (r *HookRunner) Fire(ctx context.Context, event string, envVars map[string]
 			default:
 				fmt.Fprintf(r.logOut, "[hooks] warning: %s[%d] failed (unknown policy %q): %v\n", event, i, policy, err)
 			}
+		} else {
+			// Emit hook_fired trace event
+			trace.WriteEvent(trace.ComponentHooks, trace.TypeHookFired, trace.LevelInfo,
+				trace.WithData(map[string]any{
+					"event":   event,
+					"index":   i,
+					"command": h.Command,
+				}))
 		}
 	}
 

--- a/internal/trace/event.go
+++ b/internal/trace/event.go
@@ -11,6 +11,8 @@ const (
 	ComponentWorker    = "worker"
 	ComponentReviewer  = "reviewer"
 	ComponentGitHub    = "github"
+	ComponentHooks     = "hooks"
+	ComponentAudit     = "audit"
 )
 
 // Level represents the severity/type of an event.
@@ -49,6 +51,19 @@ const (
 	TypeReviewStart    = "review_start"
 	TypeReviewDecision = "review_decision"
 	TypeReviewEnd      = "review_end"
+
+	// Hook events
+	TypeHookFired  = "hook_fired"
+	TypeHookFailed = "hook_failed"
+
+	// Audit events
+	TypeAuditTriggered = "audit_triggered"
+
+	// Workflow events
+	TypeWorkflowStop = "workflow_stop"
+
+	// Worker retry
+	TypeWorkerRetry = "worker_retry"
 )
 
 // Event represents a single trace event in the unified event stream.

--- a/internal/trace/reader.go
+++ b/internal/trace/reader.go
@@ -94,6 +94,39 @@ func (r *EventReader) ListSessions() ([]string, error) {
 	return sessions, nil
 }
 
+// ReadAllSessions reads all events across all sessions.
+func (r *EventReader) ReadAllSessions() ([]Event, error) {
+	sessions, err := r.ListSessions()
+	if err != nil {
+		return nil, err
+	}
+
+	var allEvents []Event
+	for _, sessionID := range sessions {
+		events, err := r.ReadSession(sessionID)
+		if err != nil {
+			continue
+		}
+		allEvents = append(allEvents, events...)
+	}
+
+	sort.Slice(allEvents, func(i, j int) bool {
+		return allEvents[i].Timestamp.Before(allEvents[j].Timestamp)
+	})
+
+	return allEvents, nil
+}
+
+// ReadAllSessionsFiltered reads all events across all sessions with filtering.
+func (r *EventReader) ReadAllSessionsFiltered(filter EventFilter) ([]Event, error) {
+	events, err := r.ReadAllSessions()
+	if err != nil {
+		return nil, err
+	}
+
+	return r.applyFilter(events, filter), nil
+}
+
 // ReadByIssue reads all events related to a specific issue across all sessions.
 func (r *EventReader) ReadByIssue(issueID int) ([]Event, error) {
 	sessions, err := r.ListSessions()

--- a/internal/trace/trace_test.go
+++ b/internal/trace/trace_test.go
@@ -382,3 +382,114 @@ func TestEventWriter_FilePath(t *testing.T) {
 		t.Errorf("expected path %s, got %s", expected, writer.FilePath())
 	}
 }
+
+func TestNewEventTypes(t *testing.T) {
+	// Verify new event type constants exist and are non-empty
+	types := []string{
+		TypeHookFired, TypeHookFailed,
+		TypeAuditTriggered, TypeWorkflowStop, TypeWorkerRetry,
+	}
+	for _, typ := range types {
+		if typ == "" {
+			t.Error("event type constant is empty")
+		}
+	}
+
+	// Verify new component constants
+	components := []string{ComponentHooks, ComponentAudit}
+	for _, comp := range components {
+		if comp == "" {
+			t.Error("component constant is empty")
+		}
+	}
+}
+
+func TestReadAllSessions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "trace-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create 2 sessions with different events
+	w1, _ := NewEventWriter(tmpDir, "session-001")
+	w1.Write(ComponentPrincipal, TypeSessionStart, LevelInfo)
+	w1.Write(ComponentWorker, TypeWorkerStart, LevelInfo, WithIssue(10))
+	w1.Close()
+
+	w2, _ := NewEventWriter(tmpDir, "session-002")
+	w2.Write(ComponentPrincipal, TypeSessionStart, LevelInfo)
+	w2.Write(ComponentHooks, TypeHookFired, LevelInfo, WithData(map[string]any{"event": "on_merge"}))
+	w2.Write(ComponentWorker, TypeWorkerRetry, LevelWarn, WithIssue(10))
+	w2.Close()
+
+	reader := NewEventReader(tmpDir)
+
+	// ReadAllSessions should return all 5 events
+	all, err := reader.ReadAllSessions()
+	if err != nil {
+		t.Fatalf("failed to read all sessions: %v", err)
+	}
+	if len(all) != 5 {
+		t.Errorf("expected 5 events across sessions, got %d", len(all))
+	}
+}
+
+func TestReadAllSessionsFiltered(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "trace-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	w1, _ := NewEventWriter(tmpDir, "session-a")
+	w1.Write(ComponentHooks, TypeHookFired, LevelInfo)
+	w1.Write(ComponentHooks, TypeHookFailed, LevelWarn, WithErrorString("timeout"))
+	w1.Write(ComponentWorker, TypeWorkerStart, LevelInfo, WithIssue(5))
+	w1.Close()
+
+	w2, _ := NewEventWriter(tmpDir, "session-b")
+	w2.Write(ComponentWorker, TypeWorkerRetry, LevelWarn, WithIssue(5))
+	w2.Write(ComponentAudit, TypeAuditTriggered, LevelInfo)
+	w2.Close()
+
+	reader := NewEventReader(tmpDir)
+
+	// Filter by component=hooks across all sessions
+	hookEvents, err := reader.ReadAllSessionsFiltered(EventFilter{Component: ComponentHooks})
+	if err != nil {
+		t.Fatalf("failed: %v", err)
+	}
+	if len(hookEvents) != 2 {
+		t.Errorf("expected 2 hook events, got %d", len(hookEvents))
+	}
+
+	// Filter by type
+	retryEvents, err := reader.ReadAllSessionsFiltered(EventFilter{Types: []string{TypeWorkerRetry}})
+	if err != nil {
+		t.Fatalf("failed: %v", err)
+	}
+	if len(retryEvents) != 1 {
+		t.Errorf("expected 1 worker_retry event, got %d", len(retryEvents))
+	}
+
+	// Filter by issue across sessions
+	issueEvents, err := reader.ReadAllSessionsFiltered(EventFilter{IssueID: 5})
+	if err != nil {
+		t.Fatalf("failed: %v", err)
+	}
+	if len(issueEvents) != 2 {
+		t.Errorf("expected 2 events for issue 5, got %d", len(issueEvents))
+	}
+
+	// Filter by multiple types
+	multiTypeEvents, err := reader.ReadAllSessionsFiltered(EventFilter{
+		Types: []string{TypeHookFired, TypeAuditTriggered},
+	})
+	if err != nil {
+		t.Fatalf("failed: %v", err)
+	}
+	if len(multiTypeEvents) != 2 {
+		t.Errorf("expected 2 events for hook_fired+audit_triggered, got %d", len(multiTypeEvents))
+	}
+}

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -623,6 +623,15 @@ func handleWorkerFailure(ctx context.Context, opts DispatchOptions, logger *Disp
 
 	logger.Log("將在下一輪重試 (attempt %d/%d)", failCount, opts.MaxRetries)
 
+	// Emit worker_retry trace event
+	trace.WriteEvent(trace.ComponentWorker, trace.TypeWorkerRetry, trace.LevelWarn,
+		trace.WithIssue(opts.IssueNumber),
+		trace.WithData(map[string]any{
+			"attempt":     failCount,
+			"max_retries": opts.MaxRetries,
+			"reason":      failReason,
+		}))
+
 	// Remove in-progress label for retry
 	_ = ghClient.RemoveLabel(ctx, opts.IssueNumber, "in-progress")
 	logger.Log("✓ 已移除 in-progress 標籤")

--- a/internal/workflow/stop.go
+++ b/internal/workflow/stop.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/silver2dream/ai-workflow-kit/internal/session"
+	"github.com/silver2dream/ai-workflow-kit/internal/trace"
 )
 
 // StopWorkflowOptions configures the stop workflow operation
@@ -44,6 +45,17 @@ func StopWorkflow(ctx context.Context, opts StopWorkflowOptions) (*StopWorkflowR
 	// 2. Get session information
 	sessionMgr := session.NewManager(opts.StateRoot)
 	sessionID := sessionMgr.GetCurrentSessionID()
+
+	// 2b. Emit workflow_stop trace event
+	trace.WriteEvent(trace.ComponentPrincipal, trace.TypeWorkflowStop, trace.LevelInfo,
+		trace.WithData(map[string]any{
+			"reason":         opts.Reason,
+			"total_issues":   stats.TotalIssues,
+			"closed_issues":  stats.ClosedIssues,
+			"open_issues":    stats.OpenIssues,
+			"worker_failed":  stats.WorkerFailed,
+			"needs_review":   stats.NeedsReview,
+		}))
 
 	// 3. Generate report
 	report := GenerateReport(opts.Reason, stats, sessionID)


### PR DESCRIPTION
## Summary
- Add missing trace events for hooks (`hook_fired`/`hook_failed`), worker retries (`worker_retry`), epic audit (`audit_triggered`), and workflow stop (`workflow_stop`)
- Add `--all` and `--type` flags to `awkit events` CLI for cross-session querying
- Add `ReadAllSessions`/`ReadAllSessionsFiltered` to trace reader

## Changed files
- `internal/trace/event.go` — new event type + component constants
- `internal/hooks/hooks.go` — emit trace events on hook fire/fail
- `internal/worker/dispatch.go` — emit `worker_retry` on retry
- `internal/workflow/stop.go` — emit `workflow_stop` with stats
- `internal/epicaudit/audit.go` — emit `audit_triggered`
- `internal/trace/reader.go` — cross-session read methods
- `cmd/awkit/events.go` — `--all`, `--type` flags, new component colors
- `internal/trace/trace_test.go` — tests for new types and cross-session queries

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/trace/...` passes (including 3 new tests)
- [x] `go test ./internal/hooks/... ./internal/workflow/... ./internal/epicaudit/...` passes
- [x] No regressions in `cmd/awkit` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)