### PR TITLE
[feat] add step dependency graph to spec template

### DIFF
--- a/.ai/skills/principal-workflow/tasks/create-task.md
+++ b/.ai/skills/principal-workflow/tasks/create-task.md
@@ -34,12 +34,28 @@
 - 讀取 `"<specs.base_path>/$SPEC_NAME/tasks.md"` 的第 `$TASK_LINE` 行（`specs.base_path` 由 `.ai/config/workflow.yaml` 決定，預設 `.ai/specs`）
 - 讀取 `"<specs.base_path>/$SPEC_NAME/design.md"` 了解需求與架構脈絡（若存在）
 
+### 1.5) 解析 Step Dependencies（若存在）
+
+檢查 `TASK_TEXT` 是否包含 dependency 標注（格式：`(depends on: Step N)` 或 `(depends on: Steps N,M)`）。
+
+若存在 dependency 標注：
+
+1. **提取依賴的 step 編號**：從標注中解析出 step numbers。
+2. **查找對應 Issue 編號**：在 epic body 中查找已完成的 steps 對應的 Issue（格式：`- [x] #N`）。
+3. **記錄 dependency issue numbers**：用於步驟 2 中寫入 ticket body。
+
+範例：
+- `TASK_TEXT`: `"Add RPC handlers (depends on: Step 3)"`
+- Epic body 中 Step 3 對應 `- [x] #42`
+- 則此 task depends on Issue #42
+
 ### 2) 撰寫 ticket body 草稿（只寫內容，不要直接 `gh issue create`）
 
 把 ticket body 寫入：`.ai/temp/create-task-body.md`
 
 必備 section（標題需符合）：
 - `## Summary`
+- `## Dependencies` (若有 step dependencies)
 - `## Scope`
 - `## Acceptance Criteria`（至少一個 `- [ ]` checkbox）
 - `## Testing Requirements`
@@ -49,6 +65,12 @@
 ```markdown
 ## Summary
 <一句話說清楚要做什麼>
+
+## Dependencies
+- Depends on: #<issue-number> (<step description>)
+- Depends on: #<issue-number> (<step description>)
+
+> **Note**: This task should not start until all dependency issues are closed.
 
 ## Scope
 - <列出要改/要加的功能點>
@@ -74,6 +96,10 @@
 - **Priority**: P2
 - **Release**: false
 ```
+
+**Dependencies section rules**:
+- If the task has no dependencies, omit the `## Dependencies` section entirely.
+- If dependency issues have not been created yet (step not yet in epic body as `- [x] #N` or `- [ ] #N`), write `Depends on: Step <N> (issue not yet created)` as a placeholder. The Principal should create prerequisite issues first.
 
 ### 3) 建立 Issue 並更新 tracking source
 
@@ -115,5 +141,6 @@ awkit create-task \
 - 這個 step 只負責「建立 Issue」，不要在這裡 dispatch worker 或 review PR。
 - Ticket body 不可空白/模板化；Acceptance Criteria 要可測、可驗收。
 - **Acceptance Criteria 不可預先指定精確的測試函數名稱**（如 `TestFooBar passes`），應描述預期行為（如 `Wall collision correctly ends the game`）。
+- **Dependency order**: When a task has dependencies, the Principal should ensure prerequisite issues are created first. `awkit analyze-next` handles dispatch ordering, but the issue body should document the relationship for human reviewers.
 - **epic 模式**: 若 epic body 中該 checkbox 已經 linked to issue，`awkit create-task` 會跳過避免重複。
 - **tasks_md 模式**: 若 `tasks.md` 該行已存在 `<!-- Issue #N -->`，`awkit create-task` 會直接 no-op（避免重複開 Issue）。

--- a/.ai/skills/principal-workflow/tasks/generate-tasks.md
+++ b/.ai/skills/principal-workflow/tasks/generate-tasks.md
@@ -25,25 +25,68 @@
 
 1. 讀取 `<base_path>/<spec>/design.md`
 2. 生成任務分解（draft）
-3. **Gap Verification（必須在 create-epic 前執行）**— 見下方 Section A.1
-4. 將驗證通過的 epic body 寫入 `.ai/temp/create-epic-body.md`，格式：
+3. **Step Dependency Extraction（若存在）**— 見下方 Section A.0
+4. **Gap Verification（必須在 create-epic 前執行）**— 見下方 Section A.1
+5. 將驗證通過的 epic body 寫入 `.ai/temp/create-epic-body.md`，格式：
    ```markdown
    # <spec-name> Task Tracking
 
    ## Tasks
 
    - [ ] Task 1 description
-   - [ ] Task 2 description
-   - [ ] Task 3 description
+   - [ ] Task 2 description (depends on: Task 1)
+   - [ ] Task 3 description (depends on: Tasks 1,2)
 
    ## Progress
 
    This is a GitHub Tracking Issue. Checkboxes update automatically when linked issues are closed.
    ```
-5. 執行：`awkit create-epic --spec "<SPEC_NAME>" --body-file .ai/temp/create-epic-body.md`
+6. 執行：`awkit create-epic --spec "<SPEC_NAME>" --body-file .ai/temp/create-epic-body.md`
    - **REQUIRED**: `--body-file` 參數必填
    - 此命令會創建 GitHub Tracking Issue 並更新 `workflow.yaml` 的 tracking mode
-6. 回到 main-loop
+7. 回到 main-loop
+
+---
+
+### Section A.0: Step Dependency Extraction
+
+Before generating the task list draft, check design.md for a `## Step Dependencies` section.
+
+#### A.0.1 Parse the dependency table
+
+If design.md contains a `## Step Dependencies` section with a markdown table, extract:
+
+| Column | Usage |
+|--------|-------|
+| **Step** | Step number (integer identifier) |
+| **Description** | Task description text |
+| **Depends On** | Dependency references: `-` (none), `Step N` (single), `Steps N,M` (multiple) |
+| **Acceptance Criteria** | Per-step acceptance criteria to include in the generated issue |
+
+#### A.0.2 Build dependency graph
+
+From the parsed table, construct an ordered task list:
+
+1. **Topological order**: Tasks with no dependencies (`-`) come first. Tasks depending on earlier steps come after their prerequisites.
+2. **Cycle detection**: If the dependency graph contains a cycle, log a warning and fall back to the table order as-is.
+3. **Parallel grouping**: Tasks whose dependencies are all satisfied at the same point may be dispatched in parallel (informational; actual dispatch is sequential per `awkit analyze-next`).
+
+#### A.0.3 Annotate task list draft
+
+When writing the epic body (step 5), include dependency information in each task line:
+
+- Tasks with no dependencies: plain text, no annotation.
+- Tasks with dependencies: append `(depends on: Step N)` or `(depends on: Steps N,M)` to the task description.
+
+This annotation is used by the Principal during `create_task` to include
+`Depends on: #<issue-number>` in the generated issue body, linking to the
+GitHub Issues of prerequisite tasks.
+
+#### A.0.4 No dependency table
+
+If design.md does not contain a `## Step Dependencies` section, skip this
+extraction and generate the task list in the order they appear in design.md
+(backward-compatible behavior).
 
 ---
 
@@ -76,6 +119,7 @@
 | 5 | **Entry point / wiring task 存在** | 新 module 需要 registration，新 route 需要 wiring |
 | 6 | Testing task 存在 | 每個 repo 至少有測試（可合併在功能 task 的 AC 中） |
 | 7 | Task 順序合理 | 基礎建設 → 核心功能 → 整合串接 → 測試驗證 |
+| 8 | **Step dependencies respected** | If a Step Dependencies table exists, task order matches topological sort of the dependency graph |
 
 #### A.1.3 輸出 Gap Report
 
@@ -91,6 +135,7 @@
 - GAP: Integration — <repo_A>/<repo_B> 串接缺少 wiring task
 - GAP: Entry point — <module> 缺少 registration/bootstrap task
 - GAP: Repo — <repo> 在 design.md 中被提及但 task list 沒有覆蓋
+- GAP: Dependency — Step <N> depends on Step <M> but is ordered before it
 ```
 
 #### A.1.4 修正流程
@@ -118,6 +163,7 @@
    ```markdown
    - [ ] 1. 任務標題
      - 描述
+     - Depends on: Step N (if dependencies exist in design.md)
      - 驗收標準
    ```
 3. 創建或更新 `<base_path>/<spec>/tasks.md`

--- a/.ai/specs/example/design.md
+++ b/.ai/specs/example/design.md
@@ -15,6 +15,26 @@ AWK 的配置使用 `type: directory`，表示這兩個子目錄不是獨立 git
 - `git.integration_branch` 為 `feat/example`
 - `specs.active` 預設為空，避免 clone 後直接產生 Issue/PR
 
+## Step Dependencies
+
+Define execution order and dependencies between tasks. The `Depends On` column
+controls which tasks must complete before a given step can start. The Principal
+uses this table to sequence issue creation and worker dispatch.
+
+| Step | Description | Depends On | Acceptance Criteria |
+|------|-------------|------------|---------------------|
+| 1 | Backend: add health check implementation | - | Health function returns stable payload, unit tests pass |
+| 2 | Frontend: show health status (stub) | Step 1 | Placeholder entrypoint exists, localization keys added |
+| 3 | CI sanity | Steps 1,2 | Root CI runs AWK offline + tests, backend go tests, frontend sanity |
+| 4 | Checkpoint | Step 3 | `awkit evaluate --offline` and `go test ./...` pass |
+
+### Dependency rules
+
+- **No dependency** (`-`): the task can start immediately.
+- **Single dependency** (`Step N`): the task starts only after step N is done.
+- **Multiple dependencies** (`Steps N,M`): all listed steps must complete first.
+- Steps without unmet dependencies may run in parallel when workers are available.
+
 ## Verification Strategy
 
 - Offline: `awkit evaluate --offline` + `go test ./...`
@@ -22,4 +42,3 @@ AWK 的配置使用 `type: directory`，表示這兩個子目錄不是獨立 git
   - AWK Offline + strict（只檢 P0）
   - Backend Go tests（`working-directory: backend`）
   - Frontend sanity checks（檢查 `Packages/manifest.json` 為有效 JSON、`Assets/` 存在）
-

--- a/.ai/specs/example/tasks.md
+++ b/.ai/specs/example/tasks.md
@@ -8,6 +8,7 @@ Sync: independent
 
 - [ ] 1. Backend: add health check
   - Repo: backend
+  - Depends on: -
   - [ ] 1.1 Add `health` implementation (function or minimal handler)
     - _Requirements: R1_
   - [ ] 1.2 Add unit tests for health payload
@@ -15,7 +16,7 @@ Sync: independent
 
 - [ ] 2. Frontend: show health status (stub)
   - Repo: frontend
-  - _depends_on: 1_
+  - Depends on: Step 1
   - [ ] 2.1 Add a minimal entrypoint/script placeholder
     - _Requirements: R2_
   - [ ] 2.2 Add localization key placeholders for UI strings
@@ -23,8 +24,10 @@ Sync: independent
 
 - [ ] 3. CI sanity
   - Repo: root
+  - Depends on: Steps 1,2
   - [ ] 3.1 Ensure root CI runs AWK offline + tests, backend go tests, frontend sanity
     - _Requirements: R3_
 
 - [ ] 4. Checkpoint
+  - Depends on: Step 3
   - Ensure `awkit evaluate --offline` and `go test ./...` pass.


### PR DESCRIPTION
## Summary
- Add a `## Step Dependencies` section to the example spec `design.md` template with a markdown table defining task execution order, dependency references, and per-step acceptance criteria
- Update `tasks.md` example to include `Depends on:` annotations matching the dependency table
- Update `generate-tasks.md` skill phase with a new Section A.0 (Step Dependency Extraction) that parses the dependency table, builds a topological order, detects cycles, and annotates epic body tasks with dependency info
- Update `create-task.md` skill phase to resolve dependency annotations to GitHub Issue numbers and include a `## Dependencies` section in generated issue bodies

## Test plan
- [ ] Verify `design.md` template renders correctly with the Step Dependencies table
- [ ] Verify `tasks.md` dependency annotations are consistent with `design.md`
- [ ] Verify `generate-tasks.md` Section A.0 instructions are clear and backward-compatible (no dependency table = skip extraction)
- [ ] Verify `create-task.md` dependency resolution logic handles: no deps, single dep, multiple deps, and not-yet-created issues
- [ ] Confirm no Go code changes are needed (template/skill-only change)

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)