### PR TITLE
[feat] include implementation plan in pr description

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,30 @@ Do not proceed if these files are missing—stop and report what you cannot find
 2. Run verification commands (build, test, lint)
 3. Print `git status --porcelain` and `git diff` for the runner to see
 
-### 4. Review feedback handling
+### 4. Implementation plan (REQUIRED before coding)
+Before making any code changes, you MUST create an implementation plan file at:
+`.ai/runs/issue-{ISSUE_ID}/plan.md`
+
+The plan MUST use this structure:
+```markdown
+## Summary
+Brief description of the approach (1-3 sentences).
+
+## Files to modify
+- `path/to/file.go` — what changes and why
+
+## Key decisions
+- Decision 1: rationale
+- Decision 2: rationale
+```
+
+Rules:
+- Write the plan FIRST, before any code changes.
+- The `{ISSUE_ID}` is the GitHub Issue number from the ticket.
+- Keep it concise — focus on approach and rationale, not implementation details.
+- The runner will include this plan in the PR description for reviewers.
+
+### 5. Review feedback handling
 If you see a `PREVIOUS REVIEW FEEDBACK` section in your prompt:
 - This means Principal rejected your previous work
 - **Address ALL issues mentioned in the feedback**

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -968,7 +968,8 @@ func RunIssue(ctx context.Context, opts RunIssueOptions) (*RunIssueResult, error
 	if trace != nil {
 		trace.StepStart("create_pr")
 	}
-	prURL, err := createOrFindPR(ctx, branch, prBase, commitMsg, opts.IssueID, opts.GHTimeout, ghRetryConfig)
+	planContent := readPlanFile(runDir)
+	prURL, err := createOrFindPR(ctx, branch, prBase, commitMsg, opts.IssueID, opts.GHTimeout, ghRetryConfig, planContent)
 	if err != nil {
 		runErr = err
 		result.Error = err.Error()
@@ -1234,6 +1235,14 @@ func writePromptFile(path, workDirInstruction, ticket, stateRoot string, issueID
 		builder.WriteString(historicalFeedback)
 		builder.WriteString("============================================================\n")
 	}
+
+	builder.WriteString(fmt.Sprintf("\nBEFORE making code changes, create an implementation plan file at:\n"))
+	builder.WriteString(fmt.Sprintf(".ai/runs/issue-%d/plan.md\n\n", issueID))
+	builder.WriteString("The plan file MUST contain:\n")
+	builder.WriteString("- ## Summary — brief description of the approach (1-3 sentences)\n")
+	builder.WriteString("- ## Files to modify — list of files and what changes\n")
+	builder.WriteString("- ## Key decisions — important implementation decisions and rationale\n")
+	builder.WriteString("Keep the plan concise. This will be included in the PR description for reviewers.\n")
 
 	builder.WriteString("\nAfter making changes:\n")
 	builder.WriteString("- Print: git status --porcelain\n")
@@ -1539,7 +1548,40 @@ func stageChanges(ctx context.Context, wtDir, repoName string, timeout time.Dura
 	return nil
 }
 
-func createOrFindPR(ctx context.Context, branch, base, title string, issueID int, timeout time.Duration, retryCfg ghutil.RetryConfig) (string, error) {
+// readPlanFile reads the implementation plan file created by the Worker.
+// Returns empty string if the file does not exist or cannot be read.
+func readPlanFile(runDir string) string {
+	planPath := filepath.Join(runDir, "plan.md")
+	data, err := os.ReadFile(planPath)
+	if err != nil {
+		return ""
+	}
+	plan := strings.TrimSpace(string(data))
+	if plan == "" {
+		return ""
+	}
+	return plan
+}
+
+// buildPRBody constructs the PR body with optional implementation plan.
+func buildPRBody(issueID int, title, plan string) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Closes #%d\n", issueID))
+
+	if plan != "" {
+		b.WriteString("\n## Implementation Plan\n\n")
+		b.WriteString(plan)
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n## Changes\n\n")
+	b.WriteString(title)
+	b.WriteString("\n")
+
+	return b.String()
+}
+
+func createOrFindPR(ctx context.Context, branch, base, title string, issueID int, timeout time.Duration, retryCfg ghutil.RetryConfig, planContent string) (string, error) {
 	if _, err := exec.LookPath("gh"); err != nil {
 		return "", fmt.Errorf("gh CLI not found in PATH")
 	}
@@ -1554,7 +1596,7 @@ func createOrFindPR(ctx context.Context, branch, base, title string, issueID int
 		return prInfo.URL, nil
 	}
 
-	body := fmt.Sprintf("Closes #%d\n\n%s", issueID, title)
+	body := buildPRBody(issueID, title, planContent)
 	prCtx, cancel := withOptionalTimeout(ctx, timeout)
 	defer cancel()
 

--- a/internal/worker/worker_plan_test.go
+++ b/internal/worker/worker_plan_test.go
@@ -1,0 +1,122 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// readPlanFile
+// ---------------------------------------------------------------------------
+
+func TestReadPlanFile_ExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.md")
+	content := "## Summary\nRefactor the module.\n\n## Files to modify\n- `foo.go` — update logic\n"
+	if err := os.WriteFile(planPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readPlanFile(dir)
+	if got == "" {
+		t.Fatal("expected non-empty plan content")
+	}
+	if !strings.Contains(got, "Refactor the module") {
+		t.Errorf("plan content should contain expected text, got: %s", got)
+	}
+}
+
+func TestReadPlanFile_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	got := readPlanFile(dir)
+	if got != "" {
+		t.Errorf("expected empty string for missing file, got: %s", got)
+	}
+}
+
+func TestReadPlanFile_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.md")
+	if err := os.WriteFile(planPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readPlanFile(dir)
+	if got != "" {
+		t.Errorf("expected empty string for empty file, got: %s", got)
+	}
+}
+
+func TestReadPlanFile_WhitespaceOnly(t *testing.T) {
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.md")
+	if err := os.WriteFile(planPath, []byte("   \n\n  \n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readPlanFile(dir)
+	if got != "" {
+		t.Errorf("expected empty string for whitespace-only file, got: %s", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildPRBody
+// ---------------------------------------------------------------------------
+
+func TestBuildPRBody_WithPlan(t *testing.T) {
+	body := buildPRBody(42, "[feat] add widget", "## Summary\nAdd a new widget.\n")
+
+	if !strings.Contains(body, "Closes #42") {
+		t.Error("body should contain Closes #42")
+	}
+	if !strings.Contains(body, "## Implementation Plan") {
+		t.Error("body should contain Implementation Plan section")
+	}
+	if !strings.Contains(body, "Add a new widget") {
+		t.Error("body should contain plan content")
+	}
+	if !strings.Contains(body, "## Changes") {
+		t.Error("body should contain Changes section")
+	}
+	if !strings.Contains(body, "[feat] add widget") {
+		t.Error("body should contain title in Changes section")
+	}
+}
+
+func TestBuildPRBody_WithoutPlan(t *testing.T) {
+	body := buildPRBody(99, "[fix] resolve crash", "")
+
+	if !strings.Contains(body, "Closes #99") {
+		t.Error("body should contain Closes #99")
+	}
+	if strings.Contains(body, "## Implementation Plan") {
+		t.Error("body should NOT contain Implementation Plan when plan is empty")
+	}
+	if !strings.Contains(body, "## Changes") {
+		t.Error("body should contain Changes section")
+	}
+	if !strings.Contains(body, "[fix] resolve crash") {
+		t.Error("body should contain title")
+	}
+}
+
+func TestBuildPRBody_PlanBeforeChanges(t *testing.T) {
+	body := buildPRBody(1, "title", "plan content here")
+
+	planIdx := strings.Index(body, "## Implementation Plan")
+	changesIdx := strings.Index(body, "## Changes")
+	closesIdx := strings.Index(body, "Closes #1")
+
+	if closesIdx < 0 || planIdx < 0 || changesIdx < 0 {
+		t.Fatal("body missing expected sections")
+	}
+	if closesIdx >= planIdx {
+		t.Error("Closes should come before Implementation Plan")
+	}
+	if planIdx >= changesIdx {
+		t.Error("Implementation Plan should come before Changes")
+	}
+}


### PR DESCRIPTION
Closes #176

## Summary

- Worker AI now writes an implementation plan to `.ai/runs/issue-{ID}/plan.md` before coding
- The runner reads the plan file and includes it in the PR body under an "Implementation Plan" section
- Graceful degradation: if no plan file exists, the PR body falls back to the previous format

## Changes

### AGENTS.md
- Added rule #4 "Implementation plan (REQUIRED before coding)" instructing Workers to create `plan.md` with Summary, Files to modify, and Key decisions sections
- Renumbered "Review feedback handling" from #4 to #5

### internal/worker/runner.go
- `writePromptFile()`: Added instructions telling the Worker to create the plan file before making code changes
- `readPlanFile(runDir)`: New helper that reads `.ai/runs/issue-{ID}/plan.md`, returns empty string on missing/empty file
- `buildPRBody(issueID, title, plan)`: New helper that constructs structured PR body with optional Implementation Plan section
- `createOrFindPR()`: Updated signature to accept `planContent` parameter, uses `buildPRBody` instead of inline `fmt.Sprintf`
- Call site updated to read plan file from `runDir` before PR creation

### internal/worker/worker_plan_test.go (new)
- 7 unit tests covering `readPlanFile` (existing/missing/empty/whitespace files) and `buildPRBody` (with/without plan, section ordering)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 31 packages)
- [x] New tests pass: `TestReadPlanFile_*` and `TestBuildPRBody_*`
- [ ] Verify graceful degradation: when no plan.md exists, PR body still contains `Closes #N` and Changes section
- [ ] Verify plan inclusion: when plan.md exists, PR body includes Implementation Plan section

🤖 Generated with [Claude Code](https://claude.com/claude-code)