### PR TITLE
[feat] add multi-model cross review via subagent

### DIFF
--- a/.ai/config/workflow.yaml
+++ b/.ai/config/workflow.yaml
@@ -286,6 +286,10 @@ review:
   score_threshold: 7
   # Merge strategy: squash | merge | rebase (default: squash)
   merge_strategy: squash
+  # Multi-model cross review: enable a second architecture-focused reviewer (model: opus)
+  # When true, pr-reviewer (sonnet) + architecture-reviewer (opus) both review each PR.
+  # Final score = pr-reviewer × 0.7 + architecture-reviewer × 0.3
+  # multi_model: false
 
 # ============================================================
 # Feedback Configuration

--- a/.ai/skills/principal-workflow/phases/review.md
+++ b/.ai/skills/principal-workflow/phases/review.md
@@ -22,3 +22,26 @@ Subagent 會獨立執行完整審查流程並返回結果：
 - `merge_failed`: 合併失敗（如 conflict）
 
 **收到結果後，直接回到 main-loop Step 1**，不要嘗試修正或重試。
+
+## 可選：Multi-Model 交叉審查
+
+當 `workflow.yaml` 中設定 `review.multi_model: true` 時，在 pr-reviewer 完成後，額外調用 architecture-reviewer 進行架構層面審查。
+
+**執行條件**：讀取 `.ai/config/workflow.yaml`，檢查 `review.multi_model` 是否為 `true`。如果未設定或為 `false`，跳過此步驟。
+
+**執行步驟**：
+
+1. 在 pr-reviewer 返回結果後（且結果不是 `review_blocked`），調用 architecture-reviewer：
+   - `subagent_type`: `"architecture-reviewer"`
+   - `description`: `"Architecture review PR #<pr_number>"`
+   - `prompt`: `"Architecture review PR #<pr_number> for Issue #<issue_number>"`
+
+2. 合併分數：
+   - 最終分數 = `pr-reviewer score × 0.7 + architecture-reviewer score × 0.3`（四捨五入取整）
+   - 如果 architecture-reviewer 發現 severity=error 的問題，最終分數上限為 6
+
+3. 合併 review body：將 architecture-reviewer 的 findings 附加到 pr-reviewer 的 review body 末尾
+
+4. 如果合併後分數低於 `score_threshold`，使用合併後的 body 執行 `awkit submit-review` 提交 `changes_requested`
+
+**注意**：architecture-reviewer 失敗或超時時，忽略其結果，僅使用 pr-reviewer 的結果（graceful degradation）。

--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -1,0 +1,112 @@
+---
+name: architecture-reviewer
+description: AWK Architecture Reviewer. Performs architecture-level review focusing on code organization, module boundaries, dependency direction, and design patterns. Used as optional second reviewer when review.multi_model is enabled.
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+You are the AWK Architecture Review Expert. You provide a **second opinion** focused on architecture and design quality, complementing the primary pr-reviewer which focuses on code correctness and test coverage.
+
+## Input
+
+You will receive PR number and Issue number.
+
+## Execution Flow
+
+### Step 1: Prepare Review Context
+
+```bash
+awkit prepare-review --pr $PR_NUMBER --issue $ISSUE_NUMBER
+```
+
+If this command fails, **IMMEDIATELY** return `review_blocked` with the error message.
+
+Record: `WORKTREE_PATH`, `TICKET` (issue body).
+
+### Step 2: Switch to Worktree and Review Architecture
+
+```bash
+cd $WORKTREE_PATH
+```
+
+Review the PR diff and changed files. Focus **exclusively** on architecture concerns:
+
+#### 2.1 Code Organization
+- Are changes in the correct module/package?
+- Do file names follow project conventions?
+- Is the code placed at the right layer (handler vs service vs repository)?
+
+#### 2.2 Module Boundaries
+- Do new dependencies cross module boundaries correctly?
+- Are interfaces used at boundaries (ports & adapters)?
+- Is there any circular dependency introduced?
+
+#### 2.3 Separation of Concerns
+- Is business logic separated from transport/infrastructure?
+- Are there any layer violations (e.g., DB queries in handlers)?
+
+#### 2.4 Interface Design
+- Are new interfaces usecase-oriented (not generic CRUD)?
+- Do interfaces follow existing naming patterns?
+- Is dependency injection used properly?
+
+#### 2.5 Error Handling Patterns
+- Are errors propagated correctly (not swallowed)?
+- Are domain errors used (not raw infrastructure errors)?
+- Are there any panics in non-startup code?
+
+#### 2.6 Concurrency Safety
+- Are shared resources protected?
+- Are goroutines managed (not fire-and-forget)?
+- Is context propagation correct?
+
+### Step 3: Produce Review
+
+Output your review in this format:
+
+```markdown
+### Architecture Review
+
+#### Findings
+
+| # | Area | Severity | Finding |
+|---|------|----------|---------|
+| 1 | Code Organization | info/warn/error | Description |
+| 2 | Module Boundaries | info/warn/error | Description |
+
+#### Score Justification
+
+[Explain your architecture score]
+
+#### Recommendations
+
+[List specific improvement suggestions, or "None - architecture is sound"]
+```
+
+### Step 4: Return Result
+
+Return your review to the Principal with:
+- `score`: 1-10 (architecture quality only)
+- `review_body`: the formatted review above
+- `findings_count`: number of findings by severity
+
+## Scoring Guide
+
+| Score | Meaning |
+|-------|---------|
+| 9-10 | Clean architecture, follows all patterns |
+| 7-8 | Good architecture, minor suggestions |
+| 5-6 | Acceptable but has design concerns |
+| 3-4 | Significant architecture issues |
+| 1-2 | Major violations, needs redesign |
+
+## What NOT to Review
+
+Do NOT duplicate the pr-reviewer's work:
+- ❌ Test coverage or test quality
+- ❌ Acceptance criteria verification
+- ❌ Commit message format
+- ❌ Line-by-line code correctness
+- ❌ Running tests or verifying assertions
+
+Focus purely on **design and architecture**.


### PR DESCRIPTION
Closes #181

## Summary
- Added `.claude/agents/architecture-reviewer.md` subagent (model: opus) focused on architecture-level review
- Modified review phase in `main-loop.md` to optionally invoke architecture-reviewer after pr-reviewer
- Added `review.multi_model` config option to `workflow.yaml` (default: disabled)

## Details
- Architecture reviewer focuses on: code organization, module boundaries, separation of concerns, interface design, dependency direction, error handling patterns, concurrency safety
- Score combination: pr-reviewer × 0.7 + architecture-reviewer × 0.3
- Graceful degradation: architecture-reviewer failure doesn't block the review
- Zero Go code changes — purely skill/agent layer

## Test plan
- [ ] Verify existing single-reviewer flow still works when `multi_model` is unset
- [ ] Enable `review.multi_model: true` and verify both reviewers are invoked
- [ ] Verify score combination logic
- [ ] Verify graceful degradation when architecture-reviewer fails