### PR TITLE
[feat] inject relevant design docs into worker prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,13 @@ If you see a `PREVIOUS REVIEW FEEDBACK` section in your prompt:
   - Suggested Improvements (what to fix)
   - CI failures (if mentioned)
 
+### 5. Design document context
+If you see a `DESIGN CONTEXT` section in your prompt:
+- This contains the relevant design document (design.md) for the current task
+- You SHOULD reference this design document to understand architectural decisions, data models, and intended behavior
+- Ensure your implementation aligns with the design specifications
+- If the design and ticket conflict, follow the ticket (it may represent a deliberate deviation)
+
 ---
 
 ## REPO TYPE SUPPORT

--- a/internal/worker/design_doc_test.go
+++ b/internal/worker/design_doc_test.go
@@ -1,0 +1,240 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExtractSpecFromSource(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		expected string
+	}{
+		{"empty source", "", ""},
+		{"audit source", "audit:finding-1", ""},
+		{"tasks.md source", "tasks.md #5", ""},
+		{"plain spec name", "my-project", "my-project"},
+		{"spec with spaces trimmed", "  my-project  ", "my-project"},
+		{"path traversal blocked", "../evil", ""},
+		{"slash blocked", "path/to/spec", ""},
+		{"backslash blocked", "path\\to\\spec", ""},
+		{"dots blocked", "some..name", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractSpecFromSource(tt.source)
+			if result != tt.expected {
+				t.Errorf("extractSpecFromSource(%q) = %q, want %q", tt.source, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolveDesignDoc(t *testing.T) {
+	t.Run("no_spec_name_returns_empty", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		ticket := "# Task\n- Repo: backend\n- Severity: P1\n"
+		result := resolveDesignDoc(tmpDir, ticket, nil)
+		if result != "" {
+			t.Errorf("expected empty, got %q", result)
+		}
+	})
+
+	t.Run("spec_from_ticket_metadata", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		specDir := filepath.Join(tmpDir, ".ai", "specs", "my-feature")
+		if err := os.MkdirAll(specDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		designContent := "# Design\n\nThis is the design doc."
+		if err := os.WriteFile(filepath.Join(specDir, "design.md"), []byte(designContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		ticket := "# Task\n- Repo: backend\n- Spec: my-feature\n"
+		result := resolveDesignDoc(tmpDir, ticket, nil)
+		if result != designContent {
+			t.Errorf("expected design content, got %q", result)
+		}
+	})
+
+	t.Run("spec_from_env_variable", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		specDir := filepath.Join(tmpDir, ".ai", "specs", "env-spec")
+		if err := os.MkdirAll(specDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		designContent := "# Env Spec Design"
+		if err := os.WriteFile(filepath.Join(specDir, "design.md"), []byte(designContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Setenv("AI_SPEC_NAME", "env-spec")
+		ticket := "# Task\n- Repo: backend\n"
+		result := resolveDesignDoc(tmpDir, ticket, nil)
+		if result != designContent {
+			t.Errorf("expected design content from env spec, got %q", result)
+		}
+	})
+
+	t.Run("design_file_not_found_returns_empty", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		ticket := "# Task\n- Spec: nonexistent-spec\n"
+		result := resolveDesignDoc(tmpDir, ticket, nil)
+		if result != "" {
+			t.Errorf("expected empty for missing design file, got %q", result)
+		}
+	})
+
+	t.Run("content_capped_at_4000_chars", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		specDir := filepath.Join(tmpDir, ".ai", "specs", "big-spec")
+		if err := os.MkdirAll(specDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Create content larger than 4000 chars
+		longContent := strings.Repeat("a", 5000)
+		if err := os.WriteFile(filepath.Join(specDir, "design.md"), []byte(longContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		ticket := "# Task\n- Spec: big-spec\n"
+		result := resolveDesignDoc(tmpDir, ticket, nil)
+		if len(result) > maxDesignDocChars+100 { // allow some room for truncation message
+			t.Errorf("expected content to be capped, got length %d", len(result))
+		}
+		if !strings.Contains(result, "[... truncated at 4000 characters ...]") {
+			t.Error("expected truncation message")
+		}
+	})
+
+	t.Run("custom_specs_config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		specDir := filepath.Join(tmpDir, "custom", "specs", "my-feature")
+		if err := os.MkdirAll(specDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		designContent := "# Custom Design"
+		if err := os.WriteFile(filepath.Join(specDir, "overview.md"), []byte(designContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		ticket := "# Task\n- Spec: my-feature\n"
+		cfg := &workflowSpecs{
+			BasePath: "custom/specs",
+			Files:    workflowSpecFiles{Design: "overview.md"},
+		}
+		result := resolveDesignDoc(tmpDir, ticket, cfg)
+		if result != designContent {
+			t.Errorf("expected custom design content, got %q", result)
+		}
+	})
+
+	t.Run("path_traversal_blocked", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		// Create a file outside the specs directory
+		secretFile := filepath.Join(tmpDir, "secret.txt")
+		if err := os.WriteFile(secretFile, []byte("secret data"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Attempt to use path traversal via spec name — should be blocked by ParseTicketMetadata
+		ticket := "# Task\n- Spec: ../../secret\n"
+		result := resolveDesignDoc(tmpDir, ticket, nil)
+		if result != "" {
+			t.Errorf("expected empty for path traversal attempt, got %q", result)
+		}
+	})
+
+	t.Run("source_field_plain_spec_name", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		specDir := filepath.Join(tmpDir, ".ai", "specs", "from-source")
+		if err := os.MkdirAll(specDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		designContent := "# Source-derived Design"
+		if err := os.WriteFile(filepath.Join(specDir, "design.md"), []byte(designContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Source is a plain spec name (not audit: or tasks.md)
+		ticket := "# Task\n- Source: from-source\n"
+		result := resolveDesignDoc(tmpDir, ticket, nil)
+		if result != designContent {
+			t.Errorf("expected design content from source field, got %q", result)
+		}
+	})
+
+	t.Run("audit_source_not_used_as_spec", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		ticket := "# Task\n- Source: audit:finding-1\n"
+		result := resolveDesignDoc(tmpDir, ticket, nil)
+		if result != "" {
+			t.Errorf("expected empty for audit source, got %q", result)
+		}
+	})
+}
+
+func TestWritePromptFileWithDesignDoc(t *testing.T) {
+	t.Run("prompt_includes_design_context", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		specDir := filepath.Join(tmpDir, ".ai", "specs", "test-spec")
+		if err := os.MkdirAll(specDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		designContent := "# Test Design\nSome design details."
+		if err := os.WriteFile(filepath.Join(specDir, "design.md"), []byte(designContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		promptPath := filepath.Join(tmpDir, "prompt.txt")
+		ticket := "# Task\n- Spec: test-spec\n- Repo: backend\n"
+		err := writePromptFile(promptPath, "", ticket, tmpDir, 999, 0, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		data, err := os.ReadFile(promptPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		prompt := string(data)
+
+		if !strings.Contains(prompt, "DESIGN CONTEXT") {
+			t.Error("expected prompt to contain DESIGN CONTEXT header")
+		}
+		if !strings.Contains(prompt, designContent) {
+			t.Error("expected prompt to contain design doc content")
+		}
+		// Design context should appear before the ticket
+		designIdx := strings.Index(prompt, "DESIGN CONTEXT")
+		ticketIdx := strings.Index(prompt, "Ticket:")
+		if designIdx > ticketIdx {
+			t.Error("expected DESIGN CONTEXT to appear before Ticket")
+		}
+	})
+
+	t.Run("prompt_without_design_doc", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		promptPath := filepath.Join(tmpDir, "prompt.txt")
+		ticket := "# Task\n- Repo: backend\n"
+		err := writePromptFile(promptPath, "", ticket, tmpDir, 999, 0, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		data, err := os.ReadFile(promptPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		prompt := string(data)
+
+		if strings.Contains(prompt, "DESIGN CONTEXT") {
+			t.Error("expected prompt NOT to contain DESIGN CONTEXT when no spec")
+		}
+	})
+}

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -48,6 +48,16 @@ type workflowConfig struct {
 	Timeouts   workflowTimeouts   `yaml:"timeouts"`
 	Feedback   workflowFeedback   `yaml:"feedback"`
 	Worker     workflowWorker     `yaml:"worker"`
+	Specs      workflowSpecs      `yaml:"specs"`
+}
+
+type workflowSpecs struct {
+	BasePath string            `yaml:"base_path"`
+	Files    workflowSpecFiles `yaml:"files"`
+}
+
+type workflowSpecFiles struct {
+	Design string `yaml:"design"`
 }
 
 type workflowWorker struct {
@@ -598,7 +608,7 @@ func RunIssue(ctx context.Context, opts RunIssueOptions) (*RunIssueResult, error
 
 	workDirInstruction := buildWorkDirInstruction(repoType, repoPath, workDir, repoName)
 	promptFile := filepath.Join(runDir, "prompt.txt")
-	if err := writePromptFile(promptFile, workDirInstruction, string(ticketBody), stateRoot, opts.IssueID, opts.GHTimeout, &cfg.Feedback); err != nil {
+	if err := writePromptFile(promptFile, workDirInstruction, string(ticketBody), stateRoot, opts.IssueID, opts.GHTimeout, &cfg.Feedback, &cfg.Specs); err != nil {
 		runErr = err
 		logEarlyFailure(earlyFailureLog, repoName, repoType, repoPath, branch, prBase, "prompt", err.Error())
 		result.Error = err.Error()
@@ -1177,7 +1187,7 @@ func extractTitleLine(content string) string {
 	return ""
 }
 
-func writePromptFile(path, workDirInstruction, ticket, stateRoot string, issueID int, ghTimeout time.Duration, feedbackCfg *workflowFeedback) error {
+func writePromptFile(path, workDirInstruction, ticket, stateRoot string, issueID int, ghTimeout time.Duration, feedbackCfg *workflowFeedback, specsCfg *workflowSpecs) error {
 	reviewComments := fetchReviewComments(issueID, ghTimeout)
 
 	builder := strings.Builder{}
@@ -1208,6 +1218,17 @@ func writePromptFile(path, workDirInstruction, ticket, stateRoot string, issueID
 	builder.WriteString("These paths are reserved for the Principal agent and are protected.\n")
 	builder.WriteString("Attempting to access them will result in task failure.\n")
 	builder.WriteString("============================================================\n\n")
+
+	// Inject design document context before the ticket
+	if designContent := resolveDesignDoc(stateRoot, ticket, specsCfg); designContent != "" {
+		builder.WriteString("============================================================\n")
+		builder.WriteString("DESIGN CONTEXT\n")
+		builder.WriteString("============================================================\n")
+		builder.WriteString("The following design document provides context for this task:\n\n")
+		builder.WriteString(designContent)
+		builder.WriteString("\n============================================================\n\n")
+	}
+
 	builder.WriteString("Ticket:\n")
 	builder.WriteString(ticket)
 	builder.WriteString("\n")
@@ -1242,6 +1263,94 @@ func writePromptFile(path, workDirInstruction, ticket, stateRoot string, issueID
 	builder.WriteString("- Do NOT commit or push - the runner will handle that.\n")
 
 	return os.WriteFile(path, []byte(builder.String()), 0644)
+}
+
+// maxDesignDocChars is the maximum number of characters to inject from a design document.
+const maxDesignDocChars = 4000
+
+// resolveDesignDoc attempts to find and read a design.md for the task's spec.
+// It first checks the ticket's Spec field, then falls back to extracting a spec
+// name from the Source field (e.g., "audit:finding-1" maps to spec name before the colon part).
+// Returns the design doc content (capped at maxDesignDocChars) or empty string.
+func resolveDesignDoc(stateRoot, ticket string, specsCfg *workflowSpecs) string {
+	meta := ParseTicketMetadata(ticket)
+
+	// Determine spec name: prefer explicit SpecName, fall back to env, then Source-based heuristic
+	specName := resolveSpecName(meta)
+
+	if specName == "" {
+		// Try to extract spec name from Source field
+		// Source format: "audit:<finding-id>" or just a spec name
+		specName = extractSpecFromSource(meta.Source)
+	}
+
+	if specName == "" {
+		return ""
+	}
+
+	// Determine base path and design filename
+	basePath := ".ai/specs"
+	designFile := "design.md"
+	if specsCfg != nil {
+		if specsCfg.BasePath != "" {
+			basePath = specsCfg.BasePath
+		}
+		if specsCfg.Files.Design != "" {
+			designFile = specsCfg.Files.Design
+		}
+	}
+
+	// Construct the design doc path
+	designPath := filepath.Join(stateRoot, basePath, specName, designFile)
+
+	// Validate the resolved path doesn't escape the specs directory
+	absBase, err := filepath.Abs(filepath.Join(stateRoot, basePath))
+	if err != nil {
+		return ""
+	}
+	absDesign, err := filepath.Abs(designPath)
+	if err != nil {
+		return ""
+	}
+	if !strings.HasPrefix(absDesign, absBase+string(filepath.Separator)) {
+		return ""
+	}
+
+	data, err := os.ReadFile(designPath)
+	if err != nil {
+		return "" // File not found or unreadable — skip gracefully
+	}
+
+	content := string(data)
+	if len(content) > maxDesignDocChars {
+		content = content[:maxDesignDocChars] + "\n\n[... truncated at 4000 characters ...]"
+	}
+
+	return content
+}
+
+// extractSpecFromSource tries to derive a spec name from the Source metadata field.
+// Known formats:
+//   - "audit:<finding-id>" — not directly a spec, return empty
+//   - "tasks.md #<n>" — not a spec name, return empty
+//   - plain string that could be a spec name
+func extractSpecFromSource(source string) string {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return ""
+	}
+
+	// "audit:..." and "tasks.md ..." are not spec names
+	if strings.HasPrefix(source, "audit:") || strings.HasPrefix(source, "tasks.md") {
+		return ""
+	}
+
+	// Validate: no path separators, no dots (except in simple names)
+	if strings.ContainsAny(source, "/\\..") {
+		return ""
+	}
+
+	return source
 }
 
 func buildWorkDirInstruction(repoType, repoPath, workDir, repoName string) string {


### PR DESCRIPTION
## Summary
- Inject design document content from `.ai/specs/<name>/design.md` into Worker prompts, giving Workers architectural context for their tasks
- Resolve spec name from ticket `Spec:` field, `AI_SPEC_NAME` env var, or `Source:` field fallback
- Cap injected content at 4000 characters to prevent prompt bloat; skip gracefully when no design doc exists
- Add `DESIGN CONTEXT` section to AGENTS.md so Workers know how to use the injected design document

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] New unit tests cover: spec extraction from Source field, design doc resolution (with/without spec, env var, custom config, path traversal, truncation), and prompt file integration

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)