### PR TITLE
[feat] reply to pr review comments after retry fix

### DIFF
--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -1008,6 +1008,11 @@ func RunIssue(ctx context.Context, opts RunIssueOptions) (*RunIssueResult, error
 		_ = trace.StepEnd("success", "", nil)
 	}
 
+	// On retry attempts, reply to previous review comments to signal fixes
+	if attemptInfo.AttemptNumber > 1 {
+		replyToReviewComments(ctx, prURL, opts.GHTimeout)
+	}
+
 	if err := writeIssueResult(ctx, stateRoot, issueResultContext{
 		IssueID:               opts.IssueID,
 		Status:                "success",
@@ -1396,6 +1401,74 @@ func fetchReviewComments(issueID int, ghTimeout time.Duration) string {
 		result = result[len(result)-4000:]
 	}
 	return result
+}
+
+// replyToReviewComments fetches PR review comments and posts a reply to each
+// indicating the issues have been addressed. This is called on retry attempts
+// (attempt > 1) after the worker pushes fixes.
+// Failures are logged but do not block the workflow.
+func replyToReviewComments(ctx context.Context, prURL string, ghTimeout time.Duration) {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return
+	}
+
+	prNumber := ExtractPRNumber(prURL)
+	if prNumber == 0 {
+		return
+	}
+
+	if ghTimeout <= 0 {
+		ghTimeout = 60 * time.Second
+	}
+
+	ctx, cancel := withOptionalTimeout(ctx, ghTimeout)
+	defer cancel()
+
+	// Fetch PR review comments
+	output, err := ghutil.RunWithRetry(ctx, ghutil.DefaultRetryConfig(),
+		"gh", "api",
+		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", prNumber),
+		"--paginate",
+		"--jq", ".[].id",
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[WARN] replyToReviewComments: failed to fetch comments for PR #%d: %v\n", prNumber, err)
+		return
+	}
+
+	commentIDs := parseCommentIDs(string(output))
+	if len(commentIDs) == 0 {
+		return
+	}
+
+	for _, commentID := range commentIDs {
+		if _, err := ghutil.RunWithRetry(ctx, ghutil.DefaultRetryConfig(),
+			"gh", "api",
+			"--method", "POST",
+			fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments/%d/replies", prNumber, commentID),
+			"-f", "body=Addressed in the latest push. Please re-review.",
+		); err != nil {
+			fmt.Fprintf(os.Stderr, "[WARN] replyToReviewComments: failed to reply to comment %d on PR #%d: %v\n", commentID, prNumber, err)
+			// Continue to next comment; don't block on individual failures
+		}
+	}
+}
+
+// parseCommentIDs parses newline-separated comment IDs from gh api output.
+func parseCommentIDs(output string) []int {
+	var ids []int
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		id, err := strconv.Atoi(line)
+		if err != nil {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	return ids
 }
 
 func loadHistoricalFeedback(stateRoot string, maxEntries int) string {

--- a/internal/worker/worker_reply_test.go
+++ b/internal/worker/worker_reply_test.go
@@ -1,0 +1,78 @@
+package worker
+
+import (
+	"testing"
+)
+
+func TestParseCommentIDs(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect []int
+	}{
+		{
+			name:   "single id",
+			input:  "12345\n",
+			expect: []int{12345},
+		},
+		{
+			name:   "multiple ids",
+			input:  "111\n222\n333\n",
+			expect: []int{111, 222, 333},
+		},
+		{
+			name:   "empty input",
+			input:  "",
+			expect: nil,
+		},
+		{
+			name:   "whitespace only",
+			input:  "  \n  \n",
+			expect: nil,
+		},
+		{
+			name:   "mixed valid and invalid lines",
+			input:  "100\nnot_a_number\n200\n",
+			expect: []int{100, 200},
+		},
+		{
+			name:   "trailing whitespace on ids",
+			input:  " 42 \n 99 \n",
+			expect: []int{42, 99},
+		},
+		{
+			name:   "no trailing newline",
+			input:  "500",
+			expect: []int{500},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCommentIDs(tt.input)
+			if len(got) != len(tt.expect) {
+				t.Fatalf("parseCommentIDs(%q) returned %d ids, want %d", tt.input, len(got), len(tt.expect))
+			}
+			for i := range got {
+				if got[i] != tt.expect[i] {
+					t.Errorf("parseCommentIDs(%q)[%d] = %d, want %d", tt.input, i, got[i], tt.expect[i])
+				}
+			}
+		})
+	}
+}
+
+func TestReplyToReviewComments_NoPRNumber(t *testing.T) {
+	// replyToReviewComments should return early without error when
+	// given a URL that doesn't contain a valid PR number.
+	// This test verifies it doesn't panic on empty/invalid URLs.
+	replyToReviewComments(nil, "", 0)
+	replyToReviewComments(nil, "not-a-url", 0)
+}
+
+func TestReplyToReviewComments_PRNumberZero(t *testing.T) {
+	// ExtractPRNumber returns 0 for PR URL ending in /pull/0,
+	// which means the function returns early without making API calls.
+	// This is a valid edge case since PR #0 does not exist.
+	replyToReviewComments(nil, "https://github.com/owner/repo/pull/0", 0)
+}


### PR DESCRIPTION
## Summary
- Add `replyToReviewComments()` function that fetches PR review comments via `gh api` and posts a reply to each one after the worker pushes fixes on a retry attempt
- Only triggers on retry (attempt > 1), not on first run
- Non-blocking: failures are logged as warnings but do not fail the workflow

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing + new tests)
- [x] Unit tests for `parseCommentIDs` (7 cases) and `replyToReviewComments` edge cases

Closes #177