### PR TITLE
[feat] add secondary reviewers config and consensus scoring

### DIFF
--- a/.ai/config/workflow.yaml
+++ b/.ai/config/workflow.yaml
@@ -289,7 +289,15 @@ review:
   # Multi-model cross review: enable a second architecture-focused reviewer (model: opus)
   # When true, pr-reviewer (sonnet) + architecture-reviewer (opus) both review each PR.
   # Final score = pr-reviewer × 0.7 + architecture-reviewer × 0.3
+  # If any secondary finds [ERROR] severity issues, the final score is capped at 6.
   # multi_model: false
+  # secondary_reviewers:
+  #   - backend: claude
+  #     model: opus
+  #     focus_area: architecture
+  #   - backend: claude
+  #     model: sonnet
+  #     focus_area: security
 
 # ============================================================
 # Feedback Configuration

--- a/internal/analyzer/config.go
+++ b/internal/analyzer/config.go
@@ -87,9 +87,18 @@ type ClaudeCodeConfig struct {
 
 // ReviewConfig represents the review section in workflow.yaml
 type ReviewConfig struct {
-	ScoreThreshold int           `yaml:"score_threshold"`
-	MergeStrategy  string        `yaml:"merge_strategy"`
-	JiTTest        JiTTestConfig `yaml:"jittest"`
+	ScoreThreshold     int                       `yaml:"score_threshold"`
+	MergeStrategy      string                    `yaml:"merge_strategy"`
+	MultiModel         bool                      `yaml:"multi_model"`
+	SecondaryReviewers []SecondaryReviewerConfig  `yaml:"secondary_reviewers"`
+	JiTTest            JiTTestConfig              `yaml:"jittest"`
+}
+
+// SecondaryReviewerConfig configures a secondary AI reviewer for multi-model consensus.
+type SecondaryReviewerConfig struct {
+	Backend   string `yaml:"backend"`    // "claude" or "codex"
+	Model     string `yaml:"model"`      // e.g., "opus", "sonnet"
+	FocusArea string `yaml:"focus_area"` // e.g., "architecture", "security"
 }
 
 // JiTTestConfig configures Just-in-Time Test generation and execution.

--- a/internal/analyzer/config_test.go
+++ b/internal/analyzer/config_test.go
@@ -304,6 +304,81 @@ func TestIsEpicMode(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_SecondaryReviewers(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "workflow.yaml")
+
+	configContent := `
+github:
+  repo: owner/repo
+review:
+  score_threshold: 7
+  merge_strategy: squash
+  multi_model: true
+  secondary_reviewers:
+    - backend: claude
+      model: opus
+      focus_area: architecture
+    - backend: claude
+      model: sonnet
+      focus_area: security
+`
+	os.WriteFile(configPath, []byte(configContent), 0644)
+
+	config, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	if !config.Review.MultiModel {
+		t.Error("MultiModel should be true")
+	}
+	if len(config.Review.SecondaryReviewers) != 2 {
+		t.Fatalf("expected 2 secondary reviewers, got %d", len(config.Review.SecondaryReviewers))
+	}
+
+	r0 := config.Review.SecondaryReviewers[0]
+	if r0.Backend != "claude" {
+		t.Errorf("expected backend 'claude', got %q", r0.Backend)
+	}
+	if r0.Model != "opus" {
+		t.Errorf("expected model 'opus', got %q", r0.Model)
+	}
+	if r0.FocusArea != "architecture" {
+		t.Errorf("expected focus_area 'architecture', got %q", r0.FocusArea)
+	}
+
+	r1 := config.Review.SecondaryReviewers[1]
+	if r1.FocusArea != "security" {
+		t.Errorf("expected focus_area 'security', got %q", r1.FocusArea)
+	}
+}
+
+func TestLoadConfig_NoSecondaryReviewers(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "workflow.yaml")
+
+	configContent := `
+github:
+  repo: owner/repo
+review:
+  score_threshold: 8
+`
+	os.WriteFile(configPath, []byte(configContent), 0644)
+
+	config, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	if config.Review.MultiModel {
+		t.Error("MultiModel should default to false")
+	}
+	if len(config.Review.SecondaryReviewers) != 0 {
+		t.Errorf("expected 0 secondary reviewers, got %d", len(config.Review.SecondaryReviewers))
+	}
+}
+
 func TestGetEpicIssue(t *testing.T) {
 	config := &Config{
 		Specs: SpecsConfig{

--- a/internal/reviewer/consensus.go
+++ b/internal/reviewer/consensus.go
@@ -1,0 +1,83 @@
+package reviewer
+
+import "math"
+
+const (
+	// DefaultPrimaryWeight is the default weight for the primary reviewer score.
+	DefaultPrimaryWeight = 0.7
+
+	// DefaultSecondaryTotalWeight is the total weight split among all secondary reviewers.
+	DefaultSecondaryTotalWeight = 0.3
+
+	// ErrorFindingsCap is the maximum consensus score when any secondary reviewer finds error-severity issues.
+	ErrorFindingsCap = 6
+)
+
+// CalculateConsensusScore computes a weighted consensus score from primary and secondary reviews.
+//
+// Default weights: primary gets 0.7, secondary reviewers split the remaining 0.3 equally.
+// If custom weights are provided (len(weights) == 1 + len(secondaryScores)), they are used instead.
+// If any secondary reviewer's findings contain severity=error issues, the final score is capped at 6.
+//
+// The hasErrors parameter indicates whether any secondary reviewer found error-severity findings.
+func CalculateConsensusScore(primaryScore int, secondaryScores []int, weights []float64, hasErrors bool) int {
+	if len(secondaryScores) == 0 {
+		return primaryScore
+	}
+
+	// Determine weights
+	effectiveWeights := computeWeights(len(secondaryScores), weights)
+
+	// Calculate weighted sum
+	sum := float64(primaryScore) * effectiveWeights[0]
+	for i, score := range secondaryScores {
+		sum += float64(score) * effectiveWeights[i+1]
+	}
+
+	// Round to nearest integer
+	result := int(math.Round(sum))
+
+	// Clamp to [1, 10]
+	if result < 1 {
+		result = 1
+	}
+	if result > 10 {
+		result = 10
+	}
+
+	// Cap at ErrorFindingsCap if any secondary found error-severity issues
+	if hasErrors && result > ErrorFindingsCap {
+		result = ErrorFindingsCap
+	}
+
+	return result
+}
+
+// computeWeights returns the effective weight slice.
+// If custom weights are valid (correct length, sums to ~1.0), use them.
+// Otherwise, use default weights: primary 0.7, secondaries split 0.3.
+func computeWeights(numSecondary int, custom []float64) []float64 {
+	totalSlots := 1 + numSecondary
+
+	// Check if custom weights are valid
+	if len(custom) == totalSlots {
+		sum := 0.0
+		for _, w := range custom {
+			sum += w
+		}
+		// Accept if weights sum to approximately 1.0 (within 0.01 tolerance)
+		if math.Abs(sum-1.0) < 0.01 {
+			return custom
+		}
+	}
+
+	// Default weights
+	weights := make([]float64, totalSlots)
+	weights[0] = DefaultPrimaryWeight
+	secondaryWeight := DefaultSecondaryTotalWeight / float64(numSecondary)
+	for i := 1; i < totalSlots; i++ {
+		weights[i] = secondaryWeight
+	}
+
+	return weights
+}

--- a/internal/reviewer/consensus_test.go
+++ b/internal/reviewer/consensus_test.go
@@ -1,0 +1,87 @@
+package reviewer
+
+import "testing"
+
+func TestCalculateConsensusScore_NoSecondary(t *testing.T) {
+	result := CalculateConsensusScore(8, nil, nil, false)
+	if result != 8 {
+		t.Errorf("expected 8, got %d", result)
+	}
+}
+
+func TestCalculateConsensusScore_DefaultWeights(t *testing.T) {
+	// primary=8 (weight 0.7) = 5.6
+	// secondary=[6] (weight 0.3) = 1.8
+	// total = 7.4, rounded = 7
+	result := CalculateConsensusScore(8, []int{6}, nil, false)
+	if result != 7 {
+		t.Errorf("expected 7, got %d", result)
+	}
+}
+
+func TestCalculateConsensusScore_MultipleSecondary(t *testing.T) {
+	// primary=8 (weight 0.7) = 5.6
+	// secondary=[6, 4] (weight 0.15 each) = 0.9 + 0.6 = 1.5
+	// total = 7.1, rounded = 7
+	result := CalculateConsensusScore(8, []int{6, 4}, nil, false)
+	if result != 7 {
+		t.Errorf("expected 7, got %d", result)
+	}
+}
+
+func TestCalculateConsensusScore_ErrorFindingsCapped(t *testing.T) {
+	// primary=9 (weight 0.7) = 6.3
+	// secondary=[8] (weight 0.3) = 2.4
+	// total = 8.7, rounded = 9
+	// but hasErrors=true caps at 6
+	result := CalculateConsensusScore(9, []int{8}, nil, true)
+	if result != 6 {
+		t.Errorf("expected 6 (capped due to error findings), got %d", result)
+	}
+}
+
+func TestCalculateConsensusScore_ErrorFindingsNoCap(t *testing.T) {
+	// primary=4 (weight 0.7) = 2.8
+	// secondary=[3] (weight 0.3) = 0.9
+	// total = 3.7, rounded = 4
+	// hasErrors=true but 4 <= 6, no cap effect
+	result := CalculateConsensusScore(4, []int{3}, nil, true)
+	if result != 4 {
+		t.Errorf("expected 4 (already below cap), got %d", result)
+	}
+}
+
+func TestCalculateConsensusScore_CustomWeights(t *testing.T) {
+	// primary=10 (weight 0.5) = 5.0
+	// secondary=[10] (weight 0.5) = 5.0
+	// total = 10.0
+	result := CalculateConsensusScore(10, []int{10}, []float64{0.5, 0.5}, false)
+	if result != 10 {
+		t.Errorf("expected 10, got %d", result)
+	}
+}
+
+func TestCalculateConsensusScore_InvalidCustomWeightsFallback(t *testing.T) {
+	// Custom weights wrong length -> falls back to default
+	// primary=8 (weight 0.7) = 5.6
+	// secondary=[6] (weight 0.3) = 1.8
+	// total = 7.4, rounded = 7
+	result := CalculateConsensusScore(8, []int{6}, []float64{0.5}, false)
+	if result != 7 {
+		t.Errorf("expected 7 (fallback to default weights), got %d", result)
+	}
+}
+
+func TestCalculateConsensusScore_ClampLow(t *testing.T) {
+	result := CalculateConsensusScore(1, []int{1}, nil, false)
+	if result != 1 {
+		t.Errorf("expected 1, got %d", result)
+	}
+}
+
+func TestCalculateConsensusScore_ClampHigh(t *testing.T) {
+	result := CalculateConsensusScore(10, []int{10}, nil, false)
+	if result != 10 {
+		t.Errorf("expected 10, got %d", result)
+	}
+}

--- a/internal/reviewer/secondary.go
+++ b/internal/reviewer/secondary.go
@@ -1,0 +1,135 @@
+package reviewer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/silver2dream/ai-workflow-kit/internal/analyzer"
+)
+
+// SecondaryReviewResult holds the output of a secondary reviewer.
+type SecondaryReviewResult struct {
+	FocusArea string
+	Score     int
+	Findings  string
+	Error     error
+}
+
+// claudeRunnerFunc is a function variable for invoking the Claude CLI.
+// Replaced in tests to avoid real LLM calls.
+var claudeRunnerFunc = runClaudeCLI
+
+// RunSecondaryReview invokes a secondary AI reviewer on the given diff.
+// It follows the jittest pattern: call `claude --print --model <model> --max-turns 1`
+// with a review-focused prompt, then parse the output for a score and findings.
+func RunSecondaryReview(cfg analyzer.SecondaryReviewerConfig, diff string, timeout time.Duration) (score int, findings string, err error) {
+	if diff == "" {
+		return 0, "", fmt.Errorf("empty diff, nothing to review")
+	}
+	if cfg.Model == "" {
+		return 0, "", fmt.Errorf("model is required for secondary review")
+	}
+
+	prompt := buildSecondaryReviewPrompt(cfg.FocusArea, diff)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	output, err := claudeRunnerFunc(ctx, prompt, cfg.Model)
+	if err != nil {
+		return 0, "", fmt.Errorf("secondary review failed (model=%s, focus=%s): %w", cfg.Model, cfg.FocusArea, err)
+	}
+
+	score, findings = parseSecondaryReviewOutput(output)
+	return score, findings, nil
+}
+
+// buildSecondaryReviewPrompt constructs a focused review prompt for the secondary reviewer.
+func buildSecondaryReviewPrompt(focusArea, diff string) string {
+	focusInstruction := "general code quality"
+	if focusArea != "" {
+		focusInstruction = focusArea
+	}
+
+	return fmt.Sprintf(`You are a code reviewer focused on: %s
+
+Review the following diff and provide:
+1. A score from 1-10 (where 10 is perfect)
+2. Key findings related to your focus area
+
+Format your response EXACTLY as:
+SCORE: <number>
+FINDINGS:
+<your findings here>
+
+If you find any severity=error issues (critical bugs, security vulnerabilities, data loss risks),
+prefix the finding with [ERROR].
+
+Diff:
+%s`, focusInstruction, diff)
+}
+
+// parseSecondaryReviewOutput extracts score and findings from the LLM output.
+func parseSecondaryReviewOutput(output string) (int, string) {
+	score := 5 // default if parsing fails
+
+	// Extract score
+	scoreRe := regexp.MustCompile(`(?im)^SCORE:\s*(\d+)`)
+	if m := scoreRe.FindStringSubmatch(output); len(m) > 1 {
+		if parsed, err := strconv.Atoi(m[1]); err == nil && parsed >= 1 && parsed <= 10 {
+			score = parsed
+		}
+	}
+
+	// Extract findings
+	findings := ""
+	findingsRe := regexp.MustCompile(`(?ims)^FINDINGS:\s*\n(.+)`)
+	if m := findingsRe.FindStringSubmatch(output); len(m) > 1 {
+		findings = strings.TrimSpace(m[1])
+	} else {
+		// Fallback: use the whole output minus the score line as findings
+		findings = strings.TrimSpace(scoreRe.ReplaceAllString(output, ""))
+	}
+
+	return score, findings
+}
+
+// HasErrorFindings returns true if the findings contain any [ERROR] tagged items.
+func HasErrorFindings(findings string) bool {
+	return strings.Contains(findings, "[ERROR]")
+}
+
+// runClaudeCLI invokes `claude --print --model <model> --max-turns 1` with the prompt via stdin.
+func runClaudeCLI(ctx context.Context, prompt, model string) (string, error) {
+	if _, err := exec.LookPath("claude"); err != nil {
+		return "", fmt.Errorf("claude CLI not found in PATH")
+	}
+
+	args := []string{
+		"--print",
+		"--model", model,
+		"--max-turns", "1",
+	}
+
+	cmd := exec.CommandContext(ctx, "claude", args...)
+	cmd.Stdin = strings.NewReader(prompt)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("claude CLI timed out")
+		}
+		return "", fmt.Errorf("claude exited with error: %w (stderr: %s)", err, stderr.String())
+	}
+
+	return stdout.String(), nil
+}

--- a/internal/reviewer/secondary_test.go
+++ b/internal/reviewer/secondary_test.go
@@ -1,0 +1,162 @@
+package reviewer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/silver2dream/ai-workflow-kit/internal/analyzer"
+)
+
+func TestParseSecondaryReviewOutput_ValidOutput(t *testing.T) {
+	output := `SCORE: 8
+FINDINGS:
+The architecture follows clean separation of concerns.
+No critical issues found.`
+
+	score, findings := parseSecondaryReviewOutput(output)
+	if score != 8 {
+		t.Errorf("expected score 8, got %d", score)
+	}
+	if findings == "" {
+		t.Error("expected non-empty findings")
+	}
+	if !strings.Contains(findings, "clean separation") {
+		t.Errorf("expected findings to contain 'clean separation', got: %s", findings)
+	}
+}
+
+func TestParseSecondaryReviewOutput_ScoreOutOfRange(t *testing.T) {
+	output := "SCORE: 15\nFINDINGS:\nSome findings"
+	score, _ := parseSecondaryReviewOutput(output)
+	if score != 5 { // default fallback
+		t.Errorf("expected default score 5 for out-of-range, got %d", score)
+	}
+}
+
+func TestParseSecondaryReviewOutput_NoScore(t *testing.T) {
+	output := "No structured output here, just text."
+	score, findings := parseSecondaryReviewOutput(output)
+	if score != 5 { // default
+		t.Errorf("expected default score 5, got %d", score)
+	}
+	if findings == "" {
+		t.Error("expected fallback findings from raw output")
+	}
+}
+
+func TestParseSecondaryReviewOutput_ErrorFindings(t *testing.T) {
+	output := `SCORE: 4
+FINDINGS:
+[ERROR] SQL injection vulnerability in user input handling.
+Minor style issues in naming conventions.`
+
+	score, findings := parseSecondaryReviewOutput(output)
+	if score != 4 {
+		t.Errorf("expected score 4, got %d", score)
+	}
+	if !HasErrorFindings(findings) {
+		t.Error("expected HasErrorFindings to return true")
+	}
+}
+
+func TestHasErrorFindings(t *testing.T) {
+	tests := []struct {
+		findings string
+		want     bool
+	}{
+		{"[ERROR] critical bug found", true},
+		{"Minor issues only", false},
+		{"", false},
+		{"Some text [ERROR] in the middle", true},
+	}
+
+	for _, tt := range tests {
+		got := HasErrorFindings(tt.findings)
+		if got != tt.want {
+			t.Errorf("HasErrorFindings(%q) = %v, want %v", tt.findings, got, tt.want)
+		}
+	}
+}
+
+func TestRunSecondaryReview_EmptyDiff(t *testing.T) {
+	cfg := analyzer.SecondaryReviewerConfig{Model: "sonnet"}
+	_, _, err := RunSecondaryReview(cfg, "", 30*time.Second)
+	if err == nil {
+		t.Error("expected error for empty diff")
+	}
+}
+
+func TestRunSecondaryReview_EmptyModel(t *testing.T) {
+	cfg := analyzer.SecondaryReviewerConfig{Backend: "claude"}
+	_, _, err := RunSecondaryReview(cfg, "some diff", 30*time.Second)
+	if err == nil {
+		t.Error("expected error for empty model")
+	}
+}
+
+func TestRunSecondaryReview_MockedCLI(t *testing.T) {
+	// Replace the claudeRunner with a mock
+	origRunner := claudeRunnerFunc
+	defer func() { claudeRunnerFunc = origRunner }()
+
+	claudeRunnerFunc = func(ctx context.Context, prompt, model string) (string, error) {
+		return "SCORE: 7\nFINDINGS:\nLooks good overall. Minor naming issues.", nil
+	}
+
+	cfg := analyzer.SecondaryReviewerConfig{
+		Backend:   "claude",
+		Model:     "sonnet",
+		FocusArea: "architecture",
+	}
+	score, findings, err := RunSecondaryReview(cfg, "diff --git a/file.go b/file.go\n+some code", 30*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if score != 7 {
+		t.Errorf("expected score 7, got %d", score)
+	}
+	if findings == "" {
+		t.Error("expected non-empty findings")
+	}
+}
+
+func TestRunSecondaryReview_CLIError(t *testing.T) {
+	origRunner := claudeRunnerFunc
+	defer func() { claudeRunnerFunc = origRunner }()
+
+	claudeRunnerFunc = func(ctx context.Context, prompt, model string) (string, error) {
+		return "", fmt.Errorf("connection refused")
+	}
+
+	cfg := analyzer.SecondaryReviewerConfig{
+		Backend: "claude",
+		Model:   "sonnet",
+	}
+	_, _, err := RunSecondaryReview(cfg, "some diff", 30*time.Second)
+	if err == nil {
+		t.Error("expected error from CLI failure")
+	}
+}
+
+func TestBuildSecondaryReviewPrompt(t *testing.T) {
+	prompt := buildSecondaryReviewPrompt("security", "diff content here")
+	if !strings.Contains(prompt, "security") {
+		t.Error("expected prompt to contain focus area")
+	}
+	if !strings.Contains(prompt, "SCORE:") {
+		t.Error("expected prompt to contain SCORE format instruction")
+	}
+	if !strings.Contains(prompt, "diff content here") {
+		t.Error("expected prompt to contain diff")
+	}
+}
+
+func TestBuildSecondaryReviewPrompt_EmptyFocusArea(t *testing.T) {
+	prompt := buildSecondaryReviewPrompt("", "diff content")
+	if !strings.Contains(prompt, "general code quality") {
+		t.Error("expected default focus area in prompt")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `SecondaryReviewerConfig` and `MultiModel` fields to `ReviewConfig` in config.go for configuring secondary AI reviewers in workflow.yaml
- Add `RunSecondaryReview()` in `internal/reviewer/secondary.go` that invokes `claude --print` with a focus-area prompt and parses score/findings
- Add `CalculateConsensusScore()` in `internal/reviewer/consensus.go` with weighted averaging (primary 0.7, secondaries split 0.3) and error-findings cap at 6
- Add comprehensive unit tests for consensus scoring, secondary review parsing, and config parsing
- Add commented example config in workflow.yaml showing secondary_reviewers setup

Closes #184

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 30 packages)
- [x] New consensus scoring tests cover: no secondary, default weights, multiple secondaries, error cap, custom weights, invalid weights fallback, clamping
- [x] New secondary review tests cover: output parsing, error findings detection, empty diff/model validation, mocked CLI invocation
- [x] Config parsing tests cover: secondary reviewers present and absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)