### PR TITLE
[feat] add anti-rationalization tables, red flags, and review severity prefixes

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -198,7 +198,26 @@ Your review body MUST follow this exact format:
 
 ### Suggested Improvements
 
-[List any improvement suggestions, or "None" if perfect]
+Each item MUST start with a severity prefix so the author knows what is required vs optional:
+
+| Prefix | Meaning | Author Action |
+|--------|---------|---------------|
+| **Critical:** | Blocks merge | Must fix (security, data loss, broken functionality) |
+| **Important:** | Should fix before merge | Required unless explicitly waived |
+| **Nit:** | Minor / style preference | Author may ignore |
+| **Optional:** / **Consider:** | Suggestion | Worth considering but not required |
+| **FYI:** | Informational | No action needed |
+
+Format each suggestion as a bullet line beginning with the prefix:
+
+- **Critical:** `auth.go:42` — token comparison is non-constant-time, exposes timing side channel.
+- **Important:** `engine.go:118` — `HandleCollision` has no test for diagonal entry; add a case.
+- **Nit:** `engine.go:55` — variable `tmp` would read clearer as `nextHead`.
+- **FYI:** `room.go:90` — same pattern is duplicated in `lobby.go:30`; consider extracting in a follow-up.
+
+If there are zero issues, write a single line: `None`.
+
+If your verdict is `changes_requested`, the list MUST contain at least one **Critical:** or **Important:** item — otherwise the score is inconsistent with the verdict.
 
 ### Potential Risks
 
@@ -277,3 +296,37 @@ Correct (FULL criteria text from ticket + actual assertion):
 - **MUST** immediately return `review_blocked` to Principal
 
 **Violating this rule causes "self-dealing" problem - same session self-correction is invalid.**
+
+---
+
+## Common Rationalizations (READ BEFORE SHORTCUTTING)
+
+Reviewer fatigue produces predictable shortcuts. The right column is your reality check.
+
+| Rationalization | Reality |
+|---|---|
+| "Tests look like they cover it" | You haven't read the assertion. Open the test file and copy a real assertion line. Test names lie; assertions don't. |
+| "Code looks fine" | "Looks fine" without reading the diff is a rubber-stamp. Walk every changed file, not just the headers. |
+| "Implementation description is hard to write — I'll paraphrase the criterion" | That's a system-blocked anti-pattern. Implementation must describe HOW (function name + key logic), not WHAT (re-stated criterion). |
+| "Score 9 because the build passes" | Build passing is necessary, not sufficient. Score reflects correctness + tests + architecture + scope discipline, not CI status alone. |
+| "Score 5 but no Critical/Important findings" | Inconsistent. Either the issues warrant labels or the score is too low. Align verdict, score, and findings. |
+| "I'll trust the test name to imply assertion content" | Verification engine searches the assertion string in the test file. Mismatch = `review_blocked` and a wasted round. |
+| "All criteria look meta, just mark them all `(meta)`" | Real implementation criteria masquerading as meta is approval laundering. Only mark `(meta)` when the criterion describes setup/build/process, not behavior. |
+| "Worker said it works, no need to re-verify" | Self-attestation is not evidence. Read the assertion, run it through the verifier, then approve. |
+| "Suggestions don't need labels — they're all optional" | Without severity prefixes, Worker treats everything as required (or ignores everything). Tag every line. |
+
+## Red Flags (signs your review is going off-rails)
+
+If any of these are true, STOP and reconsider before submitting:
+
+- You haven't opened a single test file before approving.
+- Implementation description for two or more criteria is the same generic sentence.
+- Implementation description re-uses words from the criterion text without naming a function or location.
+- You scored ≥7 but the PR has no tests covering new logic.
+- You scored ≤6 but produced no `Critical:` or `Important:` items in Suggested Improvements.
+- CI status is `failed` but you're voting `merged`.
+- You marked every criterion as `(meta)` to avoid finding tests.
+- Your review body has zero file:line references in any section.
+- You didn't read `plan.md` to see what the Worker intended.
+
+If any red flag fires, fix the review before running `submit-review`. A `review_blocked` round and a no-op approval both cost the project — the first wastes a Worker session, the second ships defects.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,55 @@ If you see a `DESIGN CONTEXT` section in your prompt:
 
 ---
 
+## Common Rationalizations (READ BEFORE SHORTCUTTING)
+
+When you feel tempted to skip a step, the excuse is almost always in this table. The right column is your reality check.
+
+| Rationalization | Reality |
+|---|---|
+| "I'll add tests after the code works" | You won't. Test coverage is part of the change — Acceptance Criteria require it, and reviewer rejects PRs without verifiable tests. Write the test first or alongside. |
+| "This is too simple to need tests" | Simple code grows complicated. The next change to it will break silently without a test pinning behavior. |
+| "I tested it manually, it works" | Manual checks don't survive the next refactor. Reviewer cannot verify "trust me". |
+| "The failing test is probably wrong, I'll skip it" | A failing test is a signal. Either fix the test (and explain why in the PR), or fix the code. Never silently skip. |
+| "Existing code is messy, let me clean it up while I'm here" | Out-of-scope refactors balloon the diff and break unrelated things. Stay within ticket scope; file a follow-up issue if cleanup is needed. |
+| "I'll just stub this part for now" | Half-finished implementations get merged and forgotten. Either complete the slice or split into a smaller ticket. |
+| "The Acceptance Criterion is vague, I'll guess" | Don't guess. Re-read design.md; if still unclear, document your interpretation in `plan.md` so reviewer can correct or accept it. |
+| "This is what existing code does, I'll mirror it even if it's wrong" | Existing bugs aren't a license to repeat them. If you spot a real issue, note it in `plan.md` rather than propagating. |
+| "Reviewer feedback is just nitpicking, I'll push back" | Critical/Important feedback blocks merge. Read severity prefixes (see "Responding to severity-tagged feedback" below) and address everything that isn't Nit/Optional/FYI. |
+
+## Red Flags (signs your work is going off-rails)
+
+If any of these are true, STOP and reconsider before reporting completion:
+
+- You ran no tests, or only "happy path" tests, before reporting done.
+- Your diff touches files unrelated to the ticket.
+- You added a test that passes immediately without ever failing first (it may not be testing what you think).
+- You silently changed behavior that wasn't asked for.
+- You copy-pasted criterion text into `plan.md` instead of describing the actual approach.
+- You couldn't run verify commands and decided "it should work".
+- You created a new pattern instead of extending the existing one because the existing one "felt complicated".
+- You introduced a new dependency without checking if a similar one already exists in the repo.
+
+If any red flag fires, fix it before printing `git status` / `git diff`. Reviewer enforces these and a `changes_requested` round-trip is far more expensive than slowing down now.
+
+---
+
+## Responding to severity-tagged feedback
+
+Reviewer comments may be prefixed with severity tags. Respond accordingly:
+
+| Prefix | Meaning | Your action |
+|--------|---------|-------------|
+| **Critical:** | Blocks merge (security, data loss, broken functionality) | MUST fix before next push |
+| **Important:** | Should fix before merge (missing test, wrong abstraction, poor error handling) | MUST fix unless you have a strong, written reason to defer |
+| **Nit:** | Minor / style preference | OPTIONAL — fix if cheap, otherwise leave a one-line note |
+| **Optional:** / **Consider:** | Suggestion worth thinking about | OPTIONAL — your discretion |
+| **FYI:** | Informational, no action required | No fix needed; acknowledge if relevant |
+
+If a review has zero `Critical:` or `Important:` items, it should be approval-track — push a small fix and re-request review rather than re-architecting.
+
+---
+
 ## REPO TYPE SUPPORT
 
 AWK supports three repository types configured in `.ai/config/workflow.yaml`:


### PR DESCRIPTION
## Summary

Inspired by [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) patterns. Three additions to reduce shortcut-taking by Worker and Reviewer agents:

### Worker (`AGENTS.md`)
- **Common Rationalizations** table (9 entries): "I'll add tests later", scope creep, "I'll guess on vague criteria", etc. — each with reality rebuttal.
- **Red Flags** section: 8 signs work has gone off-rails (no tests run, copy-pasted criterion text in `plan.md`, out-of-scope file changes, etc.).
- **Responding to severity-tagged feedback** section so Worker treats `Critical:` / `Important:` as must-fix and `Nit:` / `Optional:` / `FYI:` as discretionary.

### Reviewer (`.claude/agents/pr-reviewer.md`)
- **Common Rationalizations** table (9 entries): rubber-stamp approval, paraphrasing criterion as implementation description, marking all criteria as `(meta)`, score/verdict mismatch, etc.
- **Red Flags** section: 9 signs review is going off-rails (no test file opened, generic descriptions, score ≥7 with no tests, score ≤6 with no Critical/Important findings, etc.).
- **Suggested Improvements** template now requires every line to start with a severity prefix (`Critical:` / `Important:` / `Nit:` / `Optional:` / `FYI:`). Inconsistency check: `changes_requested` verdict requires at least one Critical or Important item.

## Why

dotLLM-style enhancement based on the agent-skills repo's anti-rationalization pattern. Recent failures (Issue #2, #5 in tennis example project) show the Reviewer subagent often produces low-quality reviews that don't surface the real issues, and Worker often skips tests citing "trivial". Explicit excuse-rebuttals in the prompt directly target these failure modes.

## Test plan
- [ ] Verify `go build ./...` passes (no Go code changed; pure docs)
- [ ] Verify `go test ./...` passes
- [ ] Manual: read AGENTS.md and pr-reviewer.md end-to-end to confirm sections render correctly
- [ ] Future: monitor next AWK kickoff cycle to see if rationalization rate drops in plan.md / review bodies

Closes #199
Closes #200