### PR TITLE
[feat] structured review submission with in-session correction loop

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -133,15 +133,40 @@ Some acceptance criteria are meta-level (e.g., "all tests pass", "unit tests add
 5. **Code Quality**: Any debug code or obvious bugs?
 6. **Security Check**: Any sensitive information leakage?
 
-### Step 6: Submit Review
+### Step 6: Write and Submit the Structured Review
+
+Write your review as JSON to `.ai/state/reviews/pr-{PR_NUMBER}/review.json`
+(use the Write tool — do NOT format a markdown review body; the system
+renders the human-readable comment from your JSON):
+
+```json
+{
+  "score": 8,
+  "summary": "why this score",
+  "criteria": [
+    {
+      "criterion": "<acceptance criterion copied VERBATIM from the ticket>",
+      "implementation": "<function + file:line + key behavior, >=20 chars>",
+      "test_name": "<exact test function name>",
+      "assertion": "<key assertion copied VERBATIM from the test file>"
+    },
+    { "criterion": "All tests pass", "meta": true }
+  ],
+  "improvements": [
+    { "severity": "important", "location": "engine.go:118", "text": "no test for diagonal entry" }
+  ],
+  "risks": "None identified"
+}
+```
+
+Then submit:
 
 ```bash
 awkit submit-review \
   --pr $PR_NUMBER \
   --issue $ISSUE_NUMBER \
-  --score $SCORE \
   --ci-status $CI_STATUS \
-  --body "$REVIEW_BODY"
+  --body-file .ai/state/reviews/pr-$PR_NUMBER/review.json
 ```
 
 Scoring criteria:
@@ -149,6 +174,11 @@ Scoring criteria:
 - 7-8: Completed with good quality
 - 5-6: Partial completion, has issues
 - 1-4: Not completed or major issues
+
+**If the command prints `SUBMISSION INVALID` (exit code 2):** your JSON has
+a format problem, NOT an evidence problem. The output lists exactly which
+fields to fix. Fix the JSON and resubmit **in this session** — do not stop,
+do not treat it as review_blocked.
 
 ### Step 7: Return Result
 
@@ -163,38 +193,21 @@ Scoring criteria:
 
 ---
 
-## Review Body Format
+## Structured Review Field Guide
 
-Your review body MUST follow this exact format:
-
-```markdown
-### Implementation Review
-
-#### 1. [First Criterion Text]
-
-**Implementation**: [Describe the actual implementation. Must be 20+ chars, include function names and key logic.]
-
-**Code Location**: `path/to/file.go:LineNumber`
-
-#### 2. [Second Criterion Text]
-
-**Implementation**: [Description...]
-
-**Code Location**: `path/to/file.go:LineNumber`
-
-### Test Review
-
-| Criteria | Test | Key Assertion |
-|----------|------|---------------|
-| [FULL Criterion 1 text from ticket] | `TestFunctionName` | `assert.Equal(t, expected, actual)` |
-| [FULL Criterion 2 text from ticket] | `TestOtherFunction` | `require.NoError(t, err)` |
-| [Meta-criterion like "All tests pass"] | `(meta)` | `(meta)` |
-
-**CRITICAL**: The Criteria column MUST contain the **exact full text** from the ticket's acceptance criteria. Do NOT use shortened or paraphrased versions.
-
-### Score Reason
-
-[Explain why you gave this score]
+- `criteria[]` — one entry per acceptance criterion in the ticket, `criterion`
+  copied **verbatim** (the system matches them against the ticket; paraphrases
+  fail completeness).
+- `implementation` — what you actually read in the code: function names,
+  `file:line`, key behavior. Minimum 20 characters of substance.
+- `test_name` — the exact test function name you saw pass in the test output.
+- `assertion` — the key assertion line copied **verbatim** from the test file
+  (the system greps for it; paraphrases fail verification).
+- `meta: true` — only for criteria verified by the overall test run
+  ("all tests pass", "coverage maintained"); such entries may omit the other
+  evidence fields. Do NOT mark ordinary criteria as meta.
+- `improvements[].severity` — one of `critical`, `important`, `nit`,
+  `optional`, `fyi` (see the severity table below).
 
 ### Suggested Improvements
 
@@ -208,21 +221,15 @@ Each item MUST start with a severity prefix so the author knows what is required
 | **Optional:** / **Consider:** | Suggestion | Worth considering but not required |
 | **FYI:** | Informational | No action needed |
 
-Format each suggestion as a bullet line beginning with the prefix:
+In the structured submission these are `improvements[]` entries:
 
-- **Critical:** `auth.go:42` — token comparison is non-constant-time, exposes timing side channel.
-- **Important:** `engine.go:118` — `HandleCollision` has no test for diagonal entry; add a case.
-- **Nit:** `engine.go:55` — variable `tmp` would read clearer as `nextHead`.
-- **FYI:** `room.go:90` — same pattern is duplicated in `lobby.go:30`; consider extracting in a follow-up.
-
-If there are zero issues, write a single line: `None`.
-
-If your verdict is `changes_requested`, the list MUST contain at least one **Critical:** or **Important:** item — otherwise the score is inconsistent with the verdict.
-
-### Potential Risks
-
-[List any potential risks, or "None identified"]
+```json
+{ "severity": "critical", "location": "auth.go:42", "text": "token comparison is non-constant-time, exposes timing side channel" }
 ```
+
+If there are zero issues, submit an empty `improvements` array (or omit it).
+
+If your verdict is `changes_requested` (score below threshold), `improvements` MUST contain at least one `critical` or `important` entry — otherwise the score is inconsistent with the verdict and the system blocks the review.
 
 ---
 
@@ -244,50 +251,42 @@ The system will verify your submission:
    - Non-existent assertions will block the review
 
 4. **Severity Consistency**: System cross-checks score vs findings
-   - Score below threshold (changes_requested) requires at least one **Critical:** or **Important:** item
-   - Score at/above threshold (approve) must not contain any **Critical:** item
+   - Score below threshold (changes_requested) requires at least one `critical` or `important` improvement
+   - Score at/above threshold (approve) must not contain any `critical` improvement
 
-**If verification fails, the review is blocked. A NEW session will retry.**
+**Format errors (`SUBMISSION INVALID`, exit 2) are fixed by YOU in this
+session. Evidence failures (`review_blocked`) go to a NEW session — never
+self-retry those.**
 
 ---
 
 ## Common Mistakes to Avoid
 
-### Implementation Description
+### implementation field
 
-Wrong:
-```
-**Implementation**: Implemented according to requirements
-```
+Wrong: `"implementation": "Implemented according to requirements"`
 
-Wrong:
-```
-**Implementation**: The feature is complete
-```
+Wrong: `"implementation": "The feature is complete"`
 
-Correct:
-```
-**Implementation**: Implemented in `HandleCollision()` at engine.go:145. When snake head position matches wall boundary, sets `game.State = GameOver` and emits collision event.
-```
+Correct: `"implementation": "HandleCollision() at engine.go:145: when snake head position matches wall boundary, sets game.State = GameOver and emits collision event"`
 
-### Test Assertion (Criteria Column)
+### criterion / assertion fields
 
-Wrong (shortened text):
-```
-| Wall collision ends game | TestCollision | assert passes |
-```
+Wrong (paraphrased criterion): `"criterion": "Collision detection works"`
 
-Wrong (paraphrased text):
-```
-| Collision detection works | TestWallCollision | `t.Error("should end")` |
+Wrong (invented assertion): `"assertion": "assert passes"`
+
+Correct (verbatim ticket text + verbatim test-file assertion):
+
+```json
+{
+  "criterion": "Wall collision ends game and game state changes to GameOver",
+  "test_name": "TestCollisionScenarios",
+  "assertion": "assert.Equal(t, GameOver, game.State)"
+}
 ```
 
-Correct (FULL criteria text from ticket + actual assertion):
-```
-| Wall collision ends game and game state changes to GameOver | TestCollisionScenarios | `assert.Equal(t, GameOver, game.State)` |
-```
-
-**The Criteria column must match the EXACT text from the ticket's `- [ ]` lines.**
+**`criterion` must match the EXACT text from the ticket's `- [ ]` lines; `assertion` must exist verbatim in a test file.**
 
 ---
 
@@ -315,7 +314,7 @@ Reviewer fatigue produces predictable shortcuts. The right column is your realit
 | "Score 9 because the build passes" | Build passing is necessary, not sufficient. Score reflects correctness + tests + architecture + scope discipline, not CI status alone. |
 | "Score 5 but no Critical/Important findings" | Inconsistent. Either the issues warrant labels or the score is too low. Align verdict, score, and findings. |
 | "I'll trust the test name to imply assertion content" | Verification engine searches the assertion string in the test file. Mismatch = `review_blocked` and a wasted round. |
-| "All criteria look meta, just mark them all `(meta)`" | Real implementation criteria masquerading as meta is approval laundering. Only mark `(meta)` when the criterion describes setup/build/process, not behavior. |
+| "All criteria look meta, just mark them all meta" | Real implementation criteria masquerading as meta is approval laundering. Only set `"meta": true` when the criterion describes setup/build/process, not behavior. |
 | "Worker said it works, no need to re-verify" | Self-attestation is not evidence. Read the assertion, run it through the verifier, then approve. |
 | "Suggestions don't need labels — they're all optional" | Without severity prefixes, Worker treats everything as required (or ignores everything). Tag every line. |
 
@@ -329,8 +328,8 @@ If any of these are true, STOP and reconsider before submitting:
 - You scored ≥7 but the PR has no tests covering new logic.
 - You scored ≤6 but produced no `Critical:` or `Important:` items in Suggested Improvements.
 - CI status is `failed` but you're voting `merged`.
-- You marked every criterion as `(meta)` to avoid finding tests.
-- Your review body has zero file:line references in any section.
+- You marked every criterion as `"meta": true` to avoid finding tests.
+- Your submission has zero file:line references across implementation fields and improvements.
 - You didn't read `plan.md` to see what the Worker intended.
 
 If any red flag fires, fix the review before running `submit-review`. A `review_blocked` round and a no-op approval both cost the project — the first wastes a Worker session, the second ships defects.

--- a/cmd/awkit/submit_review.go
+++ b/cmd/awkit/submit_review.go
@@ -18,26 +18,38 @@ import (
 func usageSubmitReview() {
 	fmt.Fprint(os.Stderr, `Submit PR review result
 
-Usage:
+Usage (structured, preferred):
+  awkit submit-review --pr <number> --issue <number> --ci-status <passed|failed> --body-file review.json
+
+Usage (legacy markdown):
   awkit submit-review --pr <number> --issue <number> --score <1-10> --ci-status <passed|failed> --body <review>
 
 Arguments:
   --pr          PR number (required)
   --issue       Issue number (required)
-  --score       Review score 1-10 (required, threshold configurable via review.score_threshold in workflow.yaml, default: 7)
   --ci-status   CI status: passed or failed (required)
-  --body        Review body text (required)
+  --body-file   Path to a structured review JSON file (score, criteria[],
+                improvements[]; schema is printed by prepare-review).
+                Score is taken from the file; --score must be omitted or match.
+  --score       Review score 1-10 (required with --body)
+  --body        Review body markdown (legacy; parsed by regex — prefer --body-file)
 
 Options:
   --state-root  Override state root (default: git root)
   --help        Show this help
+
+Exit codes:
+  0  review submitted (see RESULT= line for the verdict)
+  2  SUBMISSION INVALID — the JSON failed schema validation; the listed
+     fields tell you exactly what to fix. Fix and resubmit in this session.
+  1  operational failure (GitHub, config, ...)
 
 Config (workflow.yaml):
   review.score_threshold  Minimum score to approve (default: 7)
   review.merge_strategy   Merge strategy: squash, merge, rebase (default: squash)
 
 Examples:
-  awkit submit-review --pr 42 --issue 25 --score 8 --ci-status passed --body "LGTM. EVIDENCE: func NewHandler"
+  awkit submit-review --pr 42 --issue 25 --ci-status passed --body-file .ai/state/reviews/pr-42/review.json
   awkit submit-review --pr 42 --issue 25 --score 5 --ci-status failed --body "Needs work"
 `)
 }
@@ -52,6 +64,7 @@ func cmdSubmitReview(args []string) int {
 	score := fs.Int("score", 0, "")
 	ciStatus := fs.String("ci-status", "", "")
 	body := fs.String("body", "", "")
+	bodyFile := fs.String("body-file", "", "")
 	stateRoot := fs.String("state-root", "", "")
 	showHelp := fs.Bool("help", false, "")
 	showHelpShort := fs.Bool("h", false, "")
@@ -78,22 +91,49 @@ func cmdSubmitReview(args []string) int {
 		return 2
 	}
 
-	if *score < 1 || *score > 10 {
-		errorf("Error: --score must be between 1 and 10\n\n")
-		usageSubmitReview()
-		return 2
-	}
-
 	if *ciStatus != "passed" && *ciStatus != "failed" {
 		errorf("Error: --ci-status must be 'passed' or 'failed'\n\n")
 		usageSubmitReview()
 		return 2
 	}
 
-	if *body == "" {
-		errorf("Error: --body is required\n\n")
-		usageSubmitReview()
-		return 2
+	// Structured path: parse + validate the JSON BEFORE any side effects so
+	// a malformed submission is corrected in-session (exit 2), never burned
+	// as a review_blocked round.
+	var structured *reviewer.StructuredReview
+	if *bodyFile != "" {
+		data, err := os.ReadFile(*bodyFile)
+		if err != nil {
+			errorf("Error: cannot read --body-file: %v\n", err)
+			return 2
+		}
+		parsed, verrs := reviewer.ParseStructuredReview(data)
+		if len(verrs) > 0 {
+			fmt.Println("SUBMISSION INVALID (fix the fields below and resubmit in this session):")
+			for _, ve := range verrs {
+				fmt.Printf("  - %s\n", ve.String())
+			}
+			return 2
+		}
+		if *score != 0 && *score != parsed.Score {
+			fmt.Println("SUBMISSION INVALID (fix the fields below and resubmit in this session):")
+			fmt.Printf("  - score: --score %d contradicts the file's \"score\": %d — omit --score or make them match\n", *score, parsed.Score)
+			return 2
+		}
+		structured = parsed
+		*score = parsed.Score
+		*body = parsed.RenderMarkdown()
+	} else {
+		if *score < 1 || *score > 10 {
+			errorf("Error: --score must be between 1 and 10\n\n")
+			usageSubmitReview()
+			return 2
+		}
+		if *body == "" {
+			errorf("Error: --body or --body-file is required\n\n")
+			usageSubmitReview()
+			return 2
+		}
 	}
 
 	// Resolve state root
@@ -139,6 +179,7 @@ func cmdSubmitReview(args []string) int {
 		MergeStrategy:  reviewSettings.MergeStrategy,
 		GHTimeout:      60 * time.Second,
 		HookRunner:     hookRunner,
+		Structured:     structured,
 	})
 
 	if err != nil {

--- a/cmd/awkit/submit_review_structured_test.go
+++ b/cmd/awkit/submit_review_structured_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeReviewFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "review.json")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// Validation runs before any side effects, so invalid submissions are safe
+// to exercise end-to-end through the command entry point.
+
+func TestSubmitReview_BodyFileInvalidJSONExits2(t *testing.T) {
+	path := writeReviewFile(t, "{not json")
+	code := cmdSubmitReview([]string{"--pr", "1", "--issue", "2", "--ci-status", "passed", "--body-file", path})
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2 (in-session correction)", code)
+	}
+}
+
+func TestSubmitReview_BodyFileFieldErrorsExit2(t *testing.T) {
+	path := writeReviewFile(t, `{"score": 8, "criteria": []}`)
+	code := cmdSubmitReview([]string{"--pr", "1", "--issue", "2", "--ci-status", "passed", "--body-file", path})
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2", code)
+	}
+}
+
+func TestSubmitReview_BodyFileMissingExits2(t *testing.T) {
+	code := cmdSubmitReview([]string{"--pr", "1", "--issue", "2", "--ci-status", "passed", "--body-file", filepath.Join(t.TempDir(), "nope.json")})
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2", code)
+	}
+}
+
+func TestSubmitReview_BodyFileScoreConflictExits2(t *testing.T) {
+	path := writeReviewFile(t, `{"score": 8, "criteria": [{"criterion": "All tests pass", "meta": true}]}`)
+	code := cmdSubmitReview([]string{"--pr", "1", "--issue", "2", "--score", "5", "--ci-status", "passed", "--body-file", path})
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2 for score conflict", code)
+	}
+}

--- a/internal/reviewer/evidence.go
+++ b/internal/reviewer/evidence.go
@@ -39,6 +39,10 @@ type VerifyOptions struct {
 	TestCommand  string        // Command to run tests
 	TestTimeout  time.Duration // Timeout for test execution
 	Language     string        // Programming language for test name validation
+	// Verifications, when non-nil, are used directly (structured submission
+	// path) and ReviewBody is NOT parsed — the lossy markdown/regex path is
+	// bypassed entirely.
+	Verifications []CriteriaVerification
 }
 
 // TestNameValidator defines interface for language-specific test name validation
@@ -218,12 +222,17 @@ func VerifyTestEvidenceWithReport(ctx context.Context, opts VerifyOptions) (*Ver
 
 	fmt.Printf("[VERIFY] Found %d acceptance criteria in ticket\n", len(criteria))
 
-	// 2. Parse criteria verifications from review body (with language-aware validation)
-	verifications, err := ParseCriteriaVerifications(opts.ReviewBody, opts.Language)
-	if err != nil {
-		return nil, &EvidenceError{
-			Code:    1,
-			Message: fmt.Sprintf("failed to parse review body: %v", err),
+	// 2. Obtain criteria verifications: directly from a structured
+	// submission when provided, else parse the review body markdown.
+	verifications := opts.Verifications
+	if verifications == nil {
+		var err error
+		verifications, err = ParseCriteriaVerifications(opts.ReviewBody, opts.Language)
+		if err != nil {
+			return nil, &EvidenceError{
+				Code:    1,
+				Message: fmt.Sprintf("failed to parse review body: %v", err),
+			}
 		}
 	}
 
@@ -234,7 +243,7 @@ func VerifyTestEvidenceWithReport(ctx context.Context, opts VerifyOptions) (*Ver
 		}
 	}
 
-	fmt.Printf("[VERIFY] Found %d verifications in review body\n", len(verifications))
+	fmt.Printf("[VERIFY] Found %d verifications\n", len(verifications))
 
 	// 3. Validate completeness - each criteria has verification
 	if err := ValidateCompleteness(criteria, verifications); err != nil {

--- a/internal/reviewer/severity.go
+++ b/internal/reviewer/severity.go
@@ -110,8 +110,12 @@ func severityOfLine(line string) (string, bool) {
 //
 // Returns nil when consistent.
 func ValidateSeverityConsistency(score, threshold int, reviewBody string) *EvidenceError {
-	counts := ParseSeverityCounts(reviewBody)
+	return ValidateSeverityCounts(score, threshold, ParseSeverityCounts(reviewBody))
+}
 
+// ValidateSeverityCounts is the counts-based core of the severity gate,
+// used directly by the structured submission path (no prose parsing).
+func ValidateSeverityCounts(score, threshold int, counts SeverityCounts) *EvidenceError {
 	if score < threshold && counts.Critical == 0 && counts.Important == 0 {
 		return &EvidenceError{
 			Code: 4,

--- a/internal/reviewer/structured.go
+++ b/internal/reviewer/structured.go
@@ -1,0 +1,314 @@
+package reviewer
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// StructuredReview is the agent-friendly review submission contract
+// (ACI: the reviewer writes structured data; humans get markdown RENDERED
+// from it — nothing is regex-parsed back out of prose).
+//
+// Submitted as JSON via `awkit submit-review --body-file review.json`.
+type StructuredReview struct {
+	Score   int    `json:"score"`             // 1-10
+	Summary string `json:"summary,omitempty"` // score reason / overall assessment
+
+	Criteria []StructuredCriterion `json:"criteria"`
+
+	Improvements []StructuredImprovement `json:"improvements,omitempty"`
+
+	Risks string `json:"risks,omitempty"`
+}
+
+// StructuredCriterion maps one acceptance criterion to its evidence.
+type StructuredCriterion struct {
+	Criterion      string `json:"criterion"`                // acceptance criterion text (verbatim from ticket)
+	Implementation string `json:"implementation,omitempty"` // where/how implemented (function, file:line, behavior)
+	TestName       string `json:"test_name,omitempty"`      // exact test function name from test output
+	Assertion      string `json:"assertion,omitempty"`      // key assertion copied verbatim from the test file
+	Meta           bool   `json:"meta,omitempty"`           // true for meta-criteria ("all tests pass")
+}
+
+// StructuredImprovement is one severity-tagged finding.
+type StructuredImprovement struct {
+	Severity string `json:"severity"`           // critical | important | nit | optional | fyi
+	Location string `json:"location,omitempty"` // file:line
+	Text     string `json:"text"`
+}
+
+// ValidationError describes one schema problem in an agent-actionable way:
+// which field, what is wrong, and how to fix it.
+type ValidationError struct {
+	Field   string `json:"field"`
+	Problem string `json:"problem"`
+	Hint    string `json:"hint,omitempty"`
+}
+
+func (e ValidationError) String() string {
+	s := e.Field + ": " + e.Problem
+	if e.Hint != "" {
+		s += " — " + e.Hint
+	}
+	return s
+}
+
+// validSeverities for improvements.
+var validSeverities = map[string]bool{
+	severityCritical: true, severityImportant: true, severityNit: true,
+	severityOptional: true, severityConsider: true, severityFYI: true,
+}
+
+// ParseStructuredReview decodes and validates a structured review
+// submission. Unknown fields are rejected (catches typos like "tests_name"
+// at the interface instead of silently dropping evidence). Returns the
+// parsed review or a list of actionable validation errors — never both.
+func ParseStructuredReview(data []byte) (*StructuredReview, []ValidationError) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+
+	var r StructuredReview
+	if err := dec.Decode(&r); err != nil {
+		return nil, []ValidationError{{
+			Field:   "(document)",
+			Problem: fmt.Sprintf("invalid JSON: %v", err),
+			Hint:    "the file must be a single JSON object; check for trailing commas, unquoted keys, or misspelled field names",
+		}}
+	}
+	// Reject trailing content after the object.
+	if dec.More() {
+		return nil, []ValidationError{{
+			Field:   "(document)",
+			Problem: "trailing content after the JSON object",
+			Hint:    "the file must contain exactly one JSON object",
+		}}
+	}
+
+	var errs []ValidationError
+	if r.Score < 1 || r.Score > 10 {
+		errs = append(errs, ValidationError{
+			Field:   "score",
+			Problem: fmt.Sprintf("must be 1-10, got %d", r.Score),
+		})
+	}
+	if len(r.Criteria) == 0 {
+		errs = append(errs, ValidationError{
+			Field:   "criteria",
+			Problem: "must contain one entry per acceptance criterion in the ticket",
+			Hint:    "copy each ticket criterion verbatim into criteria[].criterion",
+		})
+	}
+	for i, c := range r.Criteria {
+		prefix := fmt.Sprintf("criteria[%d]", i)
+		if strings.TrimSpace(c.Criterion) == "" {
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".criterion",
+				Problem: "empty",
+				Hint:    "copy the acceptance criterion text verbatim from the ticket",
+			})
+		}
+		if c.Meta {
+			continue // meta-criteria are verified by the overall test pass
+		}
+		if len(strings.TrimSpace(c.Implementation)) < minImplementationChars {
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".implementation",
+				Problem: fmt.Sprintf("must be at least %d characters describing the actual implementation", minImplementationChars),
+				Hint:    "name the function and file:line, e.g. \"HandleCollision() at engine.go:145 sets game.State = GameOver\"",
+			})
+		}
+		if strings.TrimSpace(c.TestName) == "" {
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".test_name",
+				Problem: "empty",
+				Hint:    "the exact test function name that verifies this criterion (or set \"meta\": true for criteria like \"all tests pass\")",
+			})
+		}
+		if strings.TrimSpace(c.Assertion) == "" {
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".assertion",
+				Problem: "empty",
+				Hint:    "copy the key assertion line verbatim from the test file",
+			})
+		}
+	}
+	for i, imp := range r.Improvements {
+		prefix := fmt.Sprintf("improvements[%d]", i)
+		if !validSeverities[strings.ToLower(strings.TrimSpace(imp.Severity))] {
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".severity",
+				Problem: fmt.Sprintf("unknown severity %q", imp.Severity),
+				Hint:    "one of: critical, important, nit, optional, fyi",
+			})
+		}
+		if strings.TrimSpace(imp.Text) == "" {
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".text",
+				Problem: "empty",
+			})
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errs
+	}
+	return &r, nil
+}
+
+// minImplementationChars mirrors ValidateCompleteness's minimum.
+const minImplementationChars = 20
+
+// ToVerifications converts the structured criteria directly into the
+// verification entries the evidence gate consumes — no markdown parsing,
+// no fuzzy recovery needed.
+func (r *StructuredReview) ToVerifications() []CriteriaVerification {
+	out := make([]CriteriaVerification, 0, len(r.Criteria))
+	for _, c := range r.Criteria {
+		out = append(out, CriteriaVerification{
+			Criteria:       strings.TrimSpace(c.Criterion),
+			Implementation: strings.TrimSpace(c.Implementation),
+			TestName:       strings.TrimSpace(c.TestName),
+			Assertion:      strings.TrimSpace(c.Assertion),
+			IsMeta:         c.Meta,
+		})
+	}
+	return out
+}
+
+// SeverityCounts tallies improvements directly — the structured counterpart
+// of ParseSeverityCounts, with no bullet-prefix parsing.
+func (r *StructuredReview) SeverityCounts() SeverityCounts {
+	var counts SeverityCounts
+	for _, imp := range r.Improvements {
+		switch strings.ToLower(strings.TrimSpace(imp.Severity)) {
+		case severityCritical:
+			counts.Critical++
+		case severityImportant:
+			counts.Important++
+		case severityNit:
+			counts.Nit++
+		case severityOptional, severityConsider:
+			counts.Optional++
+		case severityFYI:
+			counts.FYI++
+		}
+	}
+	return counts
+}
+
+// severityDisplay maps lowercase severities to their display prefix.
+var severityDisplay = map[string]string{
+	severityCritical:  "Critical",
+	severityImportant: "Important",
+	severityNit:       "Nit",
+	severityOptional:  "Optional",
+	severityConsider:  "Consider",
+	severityFYI:       "FYI",
+}
+
+// RenderMarkdown produces the human-readable review body from the
+// structured data, matching the established review format so PR comments,
+// feedback categorization, and humans all see the familiar shape.
+func (r *StructuredReview) RenderMarkdown() string {
+	var b strings.Builder
+
+	b.WriteString("### Implementation Review\n\n")
+	for i, c := range r.Criteria {
+		b.WriteString(fmt.Sprintf("#### %d. %s\n", i+1, strings.TrimSpace(c.Criterion)))
+		impl := strings.TrimSpace(c.Implementation)
+		if c.Meta && impl == "" {
+			impl = "(meta) verified by the overall test pass"
+		}
+		b.WriteString(fmt.Sprintf("**Implementation**: %s\n\n", impl))
+	}
+
+	b.WriteString("### Test Review\n\n")
+	b.WriteString("| Criteria | Test | Key Assertion |\n")
+	b.WriteString("|----------|------|---------------|\n")
+	for _, c := range r.Criteria {
+		test := strings.TrimSpace(c.TestName)
+		assertion := strings.TrimSpace(c.Assertion)
+		if c.Meta {
+			if test == "" {
+				test = "(meta)"
+			}
+			if assertion == "" {
+				assertion = "overall test pass"
+			}
+		}
+		b.WriteString(fmt.Sprintf("| %s | %s | %s |\n",
+			tableCell(c.Criterion), tableCell(test), tableCell(assertion)))
+	}
+	b.WriteString("\n")
+
+	if r.Summary != "" {
+		b.WriteString("### Score Reason\n\n")
+		b.WriteString(strings.TrimSpace(r.Summary))
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString("### Suggested Improvements\n\n")
+	if len(r.Improvements) == 0 {
+		b.WriteString("None\n")
+	} else {
+		for _, imp := range r.Improvements {
+			display := severityDisplay[strings.ToLower(strings.TrimSpace(imp.Severity))]
+			line := "- **" + display + ":**"
+			if loc := strings.TrimSpace(imp.Location); loc != "" {
+				line += " `" + loc + "` —"
+			}
+			line += " " + strings.TrimSpace(imp.Text)
+			b.WriteString(line + "\n")
+		}
+	}
+	b.WriteString("\n")
+
+	if r.Risks != "" {
+		b.WriteString("### Potential Risks\n\n")
+		b.WriteString(strings.TrimSpace(r.Risks))
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// tableCell makes a string safe for a markdown table cell.
+func tableCell(s string) string {
+	s = strings.Join(strings.Fields(s), " ") // collapse newlines
+	return strings.ReplaceAll(s, "|", "\\|")
+}
+
+// SubmissionContract renders the JSON schema skeleton and submission
+// instructions shown to the reviewer by prepare-review (ACI: the interface
+// states its own contract instead of relying on prompt memory).
+func SubmissionContract(prNumber, issueNumber int) string {
+	return fmt.Sprintf(`Write your review as JSON to .ai/state/reviews/pr-%d/review.json:
+
+{
+  "score": <1-10>,
+  "summary": "<why this score>",
+  "criteria": [
+    {
+      "criterion": "<acceptance criterion copied verbatim from the ticket>",
+      "implementation": "<function + file:line + behavior, >=20 chars>",
+      "test_name": "<exact test function name>",
+      "assertion": "<key assertion copied verbatim from the test file>"
+    },
+    { "criterion": "All tests pass", "meta": true }
+  ],
+  "improvements": [
+    { "severity": "critical|important|nit|optional|fyi", "location": "file.go:42", "text": "<finding>" }
+  ],
+  "risks": "<or omit>"
+}
+
+Then submit:
+  awkit submit-review --pr %d --issue %d --ci-status <passed|failed> --body-file .ai/state/reviews/pr-%d/review.json
+
+If the command exits with SUBMISSION INVALID, fix the listed fields in the
+JSON and resubmit IN THIS SESSION (format errors are yours to correct now).
+If the result is review_blocked, STOP — a new session will re-review.`,
+		prNumber, prNumber, issueNumber, prNumber)
+}

--- a/internal/reviewer/structured_test.go
+++ b/internal/reviewer/structured_test.go
@@ -1,0 +1,202 @@
+package reviewer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const validReviewJSON = `{
+  "score": 8,
+  "summary": "solid implementation with good coverage",
+  "criteria": [
+    {
+      "criterion": "Wall collision ends game",
+      "implementation": "HandleCollision() at engine.go:145 sets game.State = GameOver on boundary hit",
+      "test_name": "TestCollisionScenarios",
+      "assertion": "assert.Equal(t, GameOver, game.State)"
+    },
+    { "criterion": "All tests pass", "meta": true }
+  ],
+  "improvements": [
+    { "severity": "nit", "location": "engine.go:55", "text": "rename tmp to nextHead" }
+  ],
+  "risks": "None identified"
+}`
+
+func TestParseStructuredReview_Valid(t *testing.T) {
+	r, errs := ParseStructuredReview([]byte(validReviewJSON))
+	if len(errs) > 0 {
+		t.Fatalf("unexpected validation errors: %v", errs)
+	}
+	if r.Score != 8 || len(r.Criteria) != 2 || len(r.Improvements) != 1 {
+		t.Errorf("parsed wrong: %+v", r)
+	}
+	if !r.Criteria[1].Meta {
+		t.Error("meta flag not parsed")
+	}
+}
+
+func TestParseStructuredReview_InvalidJSON(t *testing.T) {
+	_, errs := ParseStructuredReview([]byte("{not json"))
+	if len(errs) != 1 || !strings.Contains(errs[0].Problem, "invalid JSON") {
+		t.Errorf("expected invalid-JSON error, got %v", errs)
+	}
+}
+
+func TestParseStructuredReview_UnknownFieldCaught(t *testing.T) {
+	// Typo "tests_name" must be rejected, not silently dropped.
+	bad := `{"score": 8, "criteria": [{"criterion": "c", "implementation": "long enough description here", "tests_name": "TestX", "assertion": "a"}]}`
+	_, errs := ParseStructuredReview([]byte(bad))
+	if len(errs) == 0 {
+		t.Fatal("expected error for unknown field typo")
+	}
+	if !strings.Contains(errs[0].Problem, "unknown field") && !strings.Contains(errs[0].Problem, "tests_name") {
+		t.Errorf("error should mention the typo: %v", errs)
+	}
+}
+
+func TestParseStructuredReview_FieldErrorsWithHints(t *testing.T) {
+	bad := `{
+	  "score": 0,
+	  "criteria": [
+	    { "criterion": "", "implementation": "short", "test_name": "", "assertion": "" }
+	  ],
+	  "improvements": [ { "severity": "blocker", "text": "" } ]
+	}`
+	_, errs := ParseStructuredReview([]byte(bad))
+	if len(errs) < 5 {
+		t.Fatalf("expected multiple field errors, got %d: %v", len(errs), errs)
+	}
+
+	fields := make(map[string]bool)
+	hints := 0
+	for _, e := range errs {
+		fields[e.Field] = true
+		if e.Hint != "" {
+			hints++
+		}
+	}
+	for _, want := range []string{"score", "criteria[0].criterion", "criteria[0].implementation", "criteria[0].test_name", "criteria[0].assertion", "improvements[0].severity"} {
+		if !fields[want] {
+			t.Errorf("missing error for field %s (got %v)", want, errs)
+		}
+	}
+	if hints == 0 {
+		t.Error("validation errors should carry actionable hints")
+	}
+}
+
+func TestParseStructuredReview_MetaSkipsEvidenceFields(t *testing.T) {
+	ok := `{"score": 7, "criteria": [{"criterion": "All tests pass", "meta": true}]}`
+	r, errs := ParseStructuredReview([]byte(ok))
+	if len(errs) > 0 {
+		t.Fatalf("meta criteria must not require evidence fields: %v", errs)
+	}
+	if !r.Criteria[0].Meta {
+		t.Error("meta not set")
+	}
+}
+
+func TestStructuredReview_ToVerifications(t *testing.T) {
+	r, _ := ParseStructuredReview([]byte(validReviewJSON))
+	vs := r.ToVerifications()
+	if len(vs) != 2 {
+		t.Fatalf("expected 2 verifications, got %d", len(vs))
+	}
+	if vs[0].TestName != "TestCollisionScenarios" || vs[0].Assertion != "assert.Equal(t, GameOver, game.State)" {
+		t.Errorf("verification mapping wrong: %+v", vs[0])
+	}
+	if !vs[1].IsMeta {
+		t.Error("meta flag must map to IsMeta")
+	}
+}
+
+func TestStructuredReview_SeverityCounts(t *testing.T) {
+	j := `{"score": 5, "criteria": [{"criterion": "c", "meta": true}], "improvements": [
+	  {"severity": "critical", "text": "a"},
+	  {"severity": "Important", "text": "b"},
+	  {"severity": "consider", "text": "c"}
+	]}`
+	r, errs := ParseStructuredReview([]byte(j))
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	counts := r.SeverityCounts()
+	if counts.Critical != 1 || counts.Important != 1 || counts.Optional != 1 {
+		t.Errorf("counts wrong: %+v", counts)
+	}
+}
+
+func TestStructuredReview_RenderMarkdown(t *testing.T) {
+	r, _ := ParseStructuredReview([]byte(validReviewJSON))
+	md := r.RenderMarkdown()
+
+	for _, want := range []string{
+		"### Implementation Review",
+		"#### 1. Wall collision ends game",
+		"**Implementation**: HandleCollision()",
+		"### Test Review",
+		"| Wall collision ends game | TestCollisionScenarios | assert.Equal(t, GameOver, game.State) |",
+		"### Score Reason",
+		"### Suggested Improvements",
+		"- **Nit:** `engine.go:55` — rename tmp to nextHead",
+		"### Potential Risks",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("rendered markdown missing %q:\n%s", want, md)
+		}
+	}
+}
+
+func TestStructuredReview_RenderMarkdown_EscapesPipes(t *testing.T) {
+	j := `{"score": 7, "criteria": [{"criterion": "supports a|b syntax", "implementation": "parse alternation in matcher.go:10 with split", "test_name": "TestAlternation", "assertion": "require.True(t, ok)"}]}`
+	r, errs := ParseStructuredReview([]byte(j))
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	md := r.RenderMarkdown()
+	if !strings.Contains(md, `a\|b`) {
+		t.Errorf("pipe in criterion must be escaped in table:\n%s", md)
+	}
+}
+
+// TestVerifyTestEvidence_DirectVerificationsBypassParsing proves the
+// structured path skips markdown parsing entirely: the review body is
+// garbage, but direct verifications succeed.
+func TestVerifyTestEvidence_DirectVerificationsBypassParsing(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	testContent := `package game
+import "testing"
+func TestCollisionScenarios(t *testing.T) {
+	// assert.Equal(t, GameOver, game.State)
+}
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "engine_test.go"), []byte(testContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(tmpDir, "run-test.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho '--- PASS: TestCollisionScenarios'\necho 'ok'\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := VerifyTestEvidence(context.Background(), VerifyOptions{
+		Ticket:       "## Acceptance Criteria\n- [ ] Wall collision ends game",
+		ReviewBody:   "THIS IS NOT PARSEABLE MARKDOWN AT ALL",
+		WorktreePath: tmpDir,
+		TestCommand:  "sh " + filepath.ToSlash(script),
+		Language:     "go",
+		Verifications: []CriteriaVerification{{
+			Criteria:       "Wall collision ends game",
+			Implementation: "HandleCollision() at engine.go:145 sets game.State = GameOver",
+			TestName:       "TestCollisionScenarios",
+			Assertion:      "assert.Equal(t, GameOver, game.State)",
+		}},
+	})
+	if err != nil {
+		t.Errorf("direct verifications should bypass body parsing, got: code=%d msg=%s details=%v", err.Code, err.Message, err.Details)
+	}
+}

--- a/internal/reviewer/submit.go
+++ b/internal/reviewer/submit.go
@@ -44,6 +44,10 @@ type SubmitReviewOptions struct {
 	GHTimeout      time.Duration
 	TestTimeout    time.Duration
 	HookRunner     HookFirer     // nil = no hooks
+	// Structured, when non-nil, is the agent-submitted structured review:
+	// severity counts and criteria verifications come straight from it
+	// (no prose parsing), and ReviewBody carries its rendered markdown.
+	Structured *StructuredReview
 }
 
 // SubmitReviewResult holds the result of submitting a review
@@ -208,14 +212,18 @@ func SubmitReview(ctx context.Context, opts SubmitReviewOptions) (result *Submit
 	fmt.Printf("[REVIEW] Test Command: %s\n", opts.TestCommand)
 	fmt.Printf("[REVIEW] Language: %s\n", opts.Language)
 
-	verifyReport, verifyErr := VerifyTestEvidenceWithReport(ctx, VerifyOptions{
+	verifyOpts := VerifyOptions{
 		Ticket:       opts.Ticket,
 		ReviewBody:   opts.ReviewBody,
 		WorktreePath: opts.WorktreePath,
 		TestCommand:  opts.TestCommand,
 		TestTimeout:  opts.TestTimeout,
 		Language:     opts.Language,
-	})
+	}
+	if opts.Structured != nil {
+		verifyOpts.Verifications = opts.Structured.ToVerifications()
+	}
+	verifyReport, verifyErr := VerifyTestEvidenceWithReport(ctx, verifyOpts)
 
 	if verifyErr != nil {
 		fmt.Printf("[REVIEW] ❌ Verification failed: %s\n", verifyErr.Message)
@@ -231,7 +239,13 @@ func SubmitReview(ctx context.Context, opts SubmitReviewOptions) (result *Submit
 	// severity-tagged findings must tell the same story (system-enforced
 	// counterpart of the pr-reviewer prompt contract).
 	if severityCheckEnabled(opts.StateRoot) {
-		if sevErr := ValidateSeverityConsistency(opts.Score, opts.ScoreThreshold, opts.ReviewBody); sevErr != nil {
+		var sevErr *EvidenceError
+		if opts.Structured != nil {
+			sevErr = ValidateSeverityCounts(opts.Score, opts.ScoreThreshold, opts.Structured.SeverityCounts())
+		} else {
+			sevErr = ValidateSeverityConsistency(opts.Score, opts.ScoreThreshold, opts.ReviewBody)
+		}
+		if sevErr != nil {
 			fmt.Printf("[REVIEW] ❌ Severity consistency check failed: %s\n", sevErr.Message)
 			for _, d := range sevErr.Details {
 				fmt.Printf("[REVIEW]   - %s\n", d)


### PR DESCRIPTION
ACI hardening for the reviewer handoff — the kit's most fragile agent-to-system interface. Previously the reviewer hand-formatted markdown (exact headings, bold labels, 4-column tables) that evidence.go regex-parsed back into structure; any formatting slip became a review_blocked round costing a full fresh review session, and the lossy parse forced fuzzy matching (a false-accept surface).

The direction is now reversed: the agent writes structured data and humans get markdown RENDERED from it.

- StructuredReview contract (score, criteria[] with per-criterion implementation/test_name/assertion/meta, improvements[] with typed severity, risks) submitted via submit-review --body-file review.json.
- Fail-closed validation with agent-actionable errors: exact field paths and fix hints; DisallowUnknownFields catches typos like tests_name at the interface instead of silently dropping evidence.
- Error-class separation: schema problems exit 2 with SUBMISSION INVALID before ANY side effect — the same session fixes the JSON and resubmits in seconds. Only genuine evidence failures (tests fail, assertions missing) still block to a new session.
- Evidence gate accepts direct verifications (VerifyOptions .Verifications), bypassing markdown parsing entirely; severity gate consumes typed counts (ValidateSeverityCounts) instead of parsing bullet prefixes.
- prepare-review prints the submission contract (schema skeleton + command + retry semantics) so the interface states its own contract; pr-reviewer.md rewritten for the JSON flow. Legacy --body markdown path unchanged for compatibility.