### PR TITLE
[docs] update README and docs to current state for v0.14.0

### DIFF
--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -38,11 +38,29 @@
 - **Spec 驅動**：讀取 `.ai/specs/<name>/tasks.md`（Kiro 相容）決定下一步
 - **GitHub 作為狀態機**：Issues/PR + labels 追蹤進度
 - **派工 + 審查閉環**：派工給 Worker 產 PR，再由 Principal 審查、合併或退回產生修正 issue
+- **Worker backend 可選**：`codex`（預設）或 `claude-code`（`worker.backend`）
 
-### Kit 品質
-- **Offline Gate**：離線可驗證（不需網路）
+### 審查品質
+- **結構化 review 提交**：Reviewer 提交 `review.json`（`submit-review --body-file`）；格式錯誤在同 session 修正,只有真正的證據失敗才會 block
+- **Evidence 驗證閘門**：合併前重跑測試,並驗證每條驗收標準都對應到一個通過的測試與真實斷言
+- **Multi-model 共識**（選配）：`review.multi_model` 平行執行次要審查者並套用加權評分與 `[ERROR]` 封頂 —— 由 Go 強制執行,非 agent 心算
+- **Severity/verdict 一致性閘門**：低於門檻的分數必須帶 Critical/Important 發現;通過的分數不得帶 Critical
+- **JiT 測試**（選配）：審查時從 PR diff 生成獨立測試
+
+### 學習迴圈
+- **記錄 → 蒸餾 → 注入 → 驗證**：審查拒絕被蒸餾成精簡、可提交的教訓（`.ai/state/lessons.json`）,注入後續 Worker/Reviewer prompt 並依結果結算命中/落空
+- **可升級為硬閘門**：`awkit lessons promote` 開一個人審 issue,把已驗證的教訓固化成 rule/audit 檢查
+
+### 上下文接地
+- **Design-doc 注入**：相關 `design.md` 內容加入 Worker prompt
+- **Knowledge-graph 注入**：當 `.understand-anything/knowledge-graph.json` 存在時,注入與票券相關的程式碼地圖切片（檔案 + 相依者）（`worker.knowledge_graph`）
+
+### Kit 品質與維運
+- **Offline Gate**：離線可驗證（不需網路），`awkit evaluate --offline`
 - **Strict mode**：`--strict` 強制 audit 無 P0（適用 CI/發布前）
-- **Extensibility checks**：檢查 CI 是否會被 `feat/example` 觸發（避免分支對齊誤判）
+- **跨平台**：原生 Windows 支援（ConPTY）+ Linux/macOS;完整測試套件在 CI 的 `windows-latest` 上執行
+- **Token/成本觀測**：每 session 與每 worker 的 LLM token/成本追蹤（`awkit events`、`ResultMetrics`）
+- **生命週期 hooks**：在 pre/post dispatch、pre/post review、on merge、on failure 執行 shell 命令
 
 ---
 
@@ -72,17 +90,17 @@
 ## 🛠️ 技術棧
 
 ### Offline（必備）
-- `bash`（Windows: Git Bash / WSL）
+- `bash`（Windows: Git Bash —— 部分驗證步驟會呼叫 `sh`；Principal runner 本身有原生 Windows/ConPTY 支援）
 - `git`
 - `go` 1.25+
 
 ### Offline（可選）
-- `python3` + `pyyaml` + `jsonschema` + `jinja2`（僅供 legacy 腳本使用；生成功能已內建於 `awkit`）
+- `python3`（僅用於 frontend CI 的 JSON 驗證範例；核心生成功能已內建於 `awkit`）
 
 ### Online / E2E（選配）
 - `gh`（GitHub CLI）+ `gh auth login`
-- `claude`（Claude Code）
-- `codex`（Worker）
+- `claude`（Claude Code）—— Principal 必備;`worker.backend: claude-code` 時 Worker 也需要
+- `codex` —— `worker.backend: codex`（預設）時 Worker 需要
 
 ---
 
@@ -253,6 +271,44 @@ Spec 資料夾結構（Kiro 相容）：
 
 要啟用 spec，將 spec 資料夾名稱加入 `.ai/config/workflow.yaml` 的 `specs.active`。
 
+### Config 區段
+
+`workflow.yaml` 的頂層區段（完整參考：[docs/user/configuration.md](docs/user/configuration.md)）：
+
+| 區段 | 用途 |
+|------|------|
+| `project` / `repos` | Repo 佈局、類型、各 repo 的 `verify` 命令 |
+| `git` | 整合/發布分支、commit 格式、PR 模板 |
+| `specs` / `tasks` / `audit` | Spec 來源、任務格式、audit 檢查 |
+| `github` | Issue/PR labels、repo 覆寫 |
+| `rules` / `agents` | 啟用的 kit/自訂規則與 subagents |
+| `timeouts` / `escalation` | 操作逾時、重試/失敗上限、PR 大小上限 |
+| `review` | 分數門檻、合併策略、**multi-model 共識**、**severity 閘門**、JiT 測試 |
+| `feedback` | Review feedback 記錄/注入 |
+| `lessons` | **學習迴圈**：蒸餾/注入預算、distiller model |
+| `worker` | Backend（`codex`/`claude-code`）、**knowledge-graph 注入** |
+| `hooks` | 生命週期 shell 命令 |
+
+較新選項重點：
+
+```yaml
+review:
+  score_threshold: 7
+  severity_consistency: true    # 閘門：分數 vs Critical/Important 發現（預設開）
+  multi_model: false            # 執行次要審查者 + 加權共識
+  # secondary_reviewers:
+  #   - backend: claude
+  #     model: opus
+  #     focus_area: architecture
+
+worker:
+  backend: codex                # codex（預設）| claude-code
+  knowledge_graph: auto         # auto（存在時注入）| off
+
+lessons:
+  enabled: true                 # 學習迴圈：把審查拒絕蒸餾成可重用教訓
+```
+
 ---
 
 ## 📦 Directory Monorepo 範例
@@ -277,11 +333,11 @@ Root CI workflow：`.github/workflows/ci.yml`
 **此 repo（awkit 本身）：**
 此 repo 內建的是手寫 CI 範例。`awkit generate` 預設不會改動 workflows；需要從模板生成時才使用 `--generate-ci`。
 
-包含：
-- AWK evaluation：`awkit evaluate --offline` 與 `--offline --strict`
-- Kit tests：`go test ./...`
-- Backend：`go test ./...`（在 `backend/`）
-- Frontend：`frontend/Packages/manifest.json` JSON 檢查 + 資料夾存在性
+包含四個 job：
+- `awkit_cli`（ubuntu）：`go vet`、`go test -race`（60% 覆蓋率門檻閘門）、AWK evaluation（`awkit evaluate --offline` 與 `--offline --strict`）
+- `awkit_cli_windows`（**windows-latest**）：在 Windows 跑完整 `go test ./...` 套件,守護原生 path/ConPTY/process 行為
+- `backend`（ubuntu）：在 `backend/` 跑 `go test -race ./...`
+- `frontend`（ubuntu）：`frontend/Packages/manifest.json` JSON 檢查 + 資料夾存在性
 
 ---
 
@@ -289,7 +345,7 @@ Root CI workflow：`.github/workflows/ci.yml`
 
 - 僅供 kit 維護者 / CI 使用，一般使用者可跳過。
 - 標準：`.ai/docs/evaluate.md`
-- 執行器：`awkit evaluate`
+- 執行器：`awkit evaluate --offline`（僅報告）與 `awkit evaluate --offline --strict`（任一閘門失敗即失敗,如 P0 audit 發現 —— 用於 CI/發布前檢查）
 
 ---
 
@@ -299,9 +355,11 @@ Root CI workflow：`.github/workflows/ci.yml`
 
 | 文件 | 說明 |
 |------|------|
-| [Getting Started](docs/user/getting-started.md) | 快速入門指南 |
-| [Configuration](docs/user/configuration.md) | workflow.yaml 參考 |
-| [Troubleshooting](docs/user/troubleshooting.md) | 錯誤排解 |
+| [Quick Start](docs/user/quick-start.md) | 5 分鐘快速設定 |
+| [Getting Started](docs/user/getting-started.md) | 詳細入門指南 |
+| [Configuration](docs/user/configuration.md) | 完整 `workflow.yaml` 參考 |
+| [Skills](docs/user/skills.md) | Slash-command 技能參考 |
+| [Troubleshooting](docs/user/troubleshooting.md) | 錯誤排解（含 Windows） |
 | [FAQ](docs/user/faq.md) | 常見問題 |
 
 ### 開發者文件
@@ -309,7 +367,7 @@ Root CI workflow：`.github/workflows/ci.yml`
 | 文件 | 說明 |
 |------|------|
 | [Architecture](docs/developer/architecture.md) | 系統內部架構 |
-| [API Reference](docs/developer/api-reference.md) | Scripts & modules |
+| [API Reference](docs/developer/api-reference.md) | 模組與命令 |
 | [Contributing](docs/developer/contributing.md) | 開發指南 |
 | [Testing](docs/developer/testing.md) | 測試框架 |
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,29 @@
 - **Spec-driven**: reads `.ai/specs/<name>/tasks.md` (Kiro-compatible) to decide what to do next
 - **GitHub as state machine**: uses issues/PRs + labels to track progress
 - **Dispatch + review loop**: dispatches implementation to Worker, then reviews/merges or creates fix issues
+- **Worker backend selection**: `codex` (default) or `claude-code` via `worker.backend`
 
-### Kit Quality
-- **Offline Gate**: deterministic verification (no network required)
+### Review Quality
+- **Structured review submission**: reviewer submits `review.json` (`submit-review --body-file`); schema errors are corrected in-session, only real evidence failures block
+- **Evidence verification gate**: re-runs the test suite and verifies each acceptance criterion maps to a passing test with a real assertion before merge
+- **Multi-model consensus** (opt-in): `review.multi_model` runs secondary reviewers in parallel and applies weighted scoring with an `[ERROR]`-severity cap — enforced in Go, not agent-side math
+- **Severity/verdict consistency gate**: a below-threshold score must carry a Critical/Important finding; a passing score must not carry a Critical one
+- **JiT tests** (opt-in): generates independent tests from the PR diff at review time
+
+### Learning Loop
+- **Record → distill → inject → verify**: review rejections are distilled into compact, committable lessons (`.ai/state/lessons.json`) injected into future Worker/Reviewer prompts and settled hit/miss against outcomes
+- **Promotable to hard gates**: `awkit lessons promote` opens a human-gated issue to harden a proven lesson into a rule/audit check
+
+### Context Grounding
+- **Design-doc injection**: relevant `design.md` context is added to the Worker prompt
+- **Knowledge-graph injection**: when `.understand-anything/knowledge-graph.json` exists, a ticket-relevant slice of the codebase map (files + dependents) is injected (`worker.knowledge_graph`)
+
+### Kit Quality & Ops
+- **Offline Gate**: deterministic verification (no network required) via `awkit evaluate --offline`
 - **Strict mode**: `--strict` enforces “no P0 findings” in audit (CI/release checks)
-- **Extensibility checks**: validates CI triggers on `feat/example` (branch alignment)
+- **Cross-platform**: native Windows support (ConPTY) plus Linux/macOS; the full test suite runs on `windows-latest` in CI
+- **Token/cost observability**: per-session and per-worker LLM token/cost tracking (`awkit events`, `ResultMetrics`)
+- **Lifecycle hooks**: run shell commands at pre/post dispatch, pre/post review, on merge, on failure
 
 ---
 
@@ -72,17 +90,17 @@ More details: `docs/ai-workflow-architecture.md`.
 ## 🛠️ Technology Stack
 
 ### Offline (required)
-- `bash` (Windows: Git Bash / WSL)
+- `bash` (Windows: Git Bash — some verification steps shell out to `sh`; the Principal runner itself has native Windows/ConPTY support)
 - `git`
 - `go` 1.25+
 
 ### Offline (optional)
-- `python3` + `pyyaml` + `jsonschema` + `jinja2` (only needed for legacy scripts; generation is built into `awkit`)
+- `python3` (used only for the frontend CI JSON-validation example; core generation is built into `awkit`)
 
 ### Online / E2E (optional)
 - `gh` (GitHub CLI) + `gh auth login`
-- `claude` (Claude Code)
-- `codex` (Worker)
+- `claude` (Claude Code) — required for the Principal, and for the Worker when `worker.backend: claude-code`
+- `codex` — required for the Worker when `worker.backend: codex` (default)
 
 ---
 
@@ -255,6 +273,44 @@ Spec folder structure (Kiro compatible):
 
 To enable a spec, add its folder name to `specs.active` in `.ai/config/workflow.yaml`.
 
+### Config sections
+
+`workflow.yaml` has these top-level sections (full reference: [docs/user/configuration.md](docs/user/configuration.md)):
+
+| Section | Purpose |
+|---------|---------|
+| `project` / `repos` | Repo layout, types, per-repo `verify` commands |
+| `git` | Integration/release branches, commit format, PR template |
+| `specs` / `tasks` / `audit` | Spec sources, task format, audit checks |
+| `github` | Issue/PR labels, repo override |
+| `rules` / `agents` | Enabled kit/custom rules and subagents |
+| `timeouts` / `escalation` | Operation timeouts, retry/failure limits, PR-size caps |
+| `review` | Score threshold, merge strategy, **multi-model consensus**, **severity gate**, JiT tests |
+| `feedback` | Review feedback recording/injection |
+| `lessons` | **Learning loop**: distillation/injection budget, distiller model |
+| `worker` | Backend (`codex`/`claude-code`), **knowledge-graph injection** |
+| `hooks` | Lifecycle shell commands |
+
+Highlighted newer options:
+
+```yaml
+review:
+  score_threshold: 7
+  severity_consistency: true    # gate: score vs Critical/Important findings (default on)
+  multi_model: false            # run secondary reviewers + weighted consensus
+  # secondary_reviewers:
+  #   - backend: claude
+  #     model: opus
+  #     focus_area: architecture
+
+worker:
+  backend: codex                # codex (default) | claude-code
+  knowledge_graph: auto         # auto (inject when present) | off
+
+lessons:
+  enabled: true                 # learning loop: distill review rejections into reusable lessons
+```
+
 ---
 
 ## 📦 Directory Monorepo Example
@@ -279,11 +335,11 @@ Root CI workflow: `.github/workflows/ci.yml`
 **For this repo (awkit itself):**
 This repo ships a hand-maintained CI example. `awkit generate` does **not** modify workflows unless you pass `--generate-ci`.
 
-It runs:
-- AWK evaluation: `awkit evaluate --offline` and `--offline --strict`
-- Kit tests: `go test ./...`
-- Backend tests: `go test ./...` (in `backend/`)
-- Frontend sanity: `frontend/Packages/manifest.json` JSON validation + folder checks
+It runs four jobs:
+- `awkit_cli` (ubuntu): `go vet`, `go test -race` with a 60% coverage threshold gate, and AWK evaluation (`awkit evaluate --offline` and `--offline --strict`)
+- `awkit_cli_windows` (**windows-latest**): the full `go test ./...` suite on Windows, guarding native path/ConPTY/process behavior
+- `backend` (ubuntu): `go test -race ./...` in `backend/`
+- `frontend` (ubuntu): `frontend/Packages/manifest.json` JSON validation + folder checks
 
 ---
 
@@ -302,9 +358,10 @@ It runs:
 | Document | Description |
 |----------|-------------|
 | [Quick Start](docs/user/quick-start.md) | 5-minute setup guide |
-| [Getting Started](docs/user/getting-started.md) | Detailed setup guide (zh-TW) |
-| [Configuration](docs/user/configuration.md) | workflow.yaml reference |
-| [Troubleshooting](docs/user/troubleshooting.md) | Error solutions |
+| [Getting Started](docs/user/getting-started.md) | Detailed setup guide |
+| [Configuration](docs/user/configuration.md) | Complete `workflow.yaml` reference |
+| [Skills](docs/user/skills.md) | Slash-command skills reference |
+| [Troubleshooting](docs/user/troubleshooting.md) | Error solutions (incl. Windows) |
 | [FAQ](docs/user/faq.md) | Common questions |
 
 ### For Developers
@@ -312,7 +369,7 @@ It runs:
 | Document | Description |
 |----------|-------------|
 | [Architecture](docs/developer/architecture.md) | System internals |
-| [API Reference](docs/developer/api-reference.md) | Scripts & modules |
+| [API Reference](docs/developer/api-reference.md) | Modules & commands |
 | [Contributing](docs/developer/contributing.md) | Development guide |
 | [Testing](docs/developer/testing.md) | Test framework |
 

--- a/docs/ai-workflow-architecture.md
+++ b/docs/ai-workflow-architecture.md
@@ -1,8 +1,9 @@
 # AI Autonomous Workflow Architecture
 
-> Version: 1.3
-> Last Updated: 2026-01-14
+> Version: 1.4
 > Status: Implementation Complete
+
+> **注意**：本文件為高層概念架構,部分圖表與檔案清單早於 v0.14.0 的子系統(學習迴圈 `internal/lessons`、結構化 review + multi-model 共識、knowledge-graph 注入、token/成本觀測、原生 Windows/ConPTY 支援)。整體 Principal→Worker→Reviewer 骨架仍準確;各子系統的權威說明見 [API Reference](developer/api-reference.md#主要子系統internal) 與 [Configuration](user/configuration.md)。本文件中提及的 `.ai/commands/`、`.ai/scripts/*.sh`、`repo_scan.json`/`audit.json` 等為已移除的舊實作,現以 `.ai/skills/` 與內建 Go 命令取代。
 
 ---
 

--- a/docs/developer/api-reference.md
+++ b/docs/developer/api-reference.md
@@ -23,18 +23,21 @@
 ```bash
 awkit init              # 初始化專案
 awkit init --preset go  # 使用 preset 初始化
-awkit kickoff           # 啟動工作流程
+awkit kickoff           # 啟動工作流程（audit/掃描已內建於 kickoff 迴圈）
 awkit kickoff --dry-run # 預覽執行
 awkit kickoff --resume  # 恢復上次執行
-awkit status            # 檢查狀態
+awkit status            # 檢查狀態（離線摘要）
+awkit next              # 顯示下一個動作
 awkit validate          # 驗證配置
-awkit scan-repo         # 掃描專案結構
-awkit audit-project     # 審計專案狀態
+awkit evaluate --offline  # 執行評估 gate（--strict 任一失敗即失敗）
+awkit lessons list      # 學習迴圈教訓（list/stats/add/distill/promote）
 awkit dispatch-worker   # 調度 Worker
 awkit upgrade           # 升級 kit 檔案
 awkit check-update      # 檢查更新
 awkit version           # 顯示版本
 ```
+
+> 完整命令清單見 `awkit help`。`scan-repo` / `audit-project` 等舊子命令已移除,相關邏輯內建於 `kickoff` 與 `awkit audit-epic`。
 
 ### 詳細用法
 
@@ -64,6 +67,8 @@ Skills 是 AWK 的技能系統，用於定義 Agent 的行為。
 | `principal-workflow` | Principal Agent 主工作流程 |
 | `create-issues` | Issue 建立技能 |
 | `run-issues` | Issue 執行技能 |
+| `post-mortem` | 失敗事後分析（唯讀）；學習迴圈的手動入口 |
+| `release-checklist` | 發布前 go/no-go 驗證 |
 
 ---
 
@@ -534,11 +539,43 @@ awkit generate [--generate-ci]
 
 ### awkit evaluate
 
-評估腳本。
+執行評估 gate（離線 O0–O10 + 線上 gate），輸出各 gate 狀態與評分。`--strict` 時任一 gate 失敗即以非零退出（用於 CI/發布前）。
 
 ```bash
 awkit evaluate [--offline] [--strict]
 ```
+
+### awkit lessons
+
+學習迴圈的教訓管理（見下方子系統）。
+
+```bash
+awkit lessons list [--all]         # 列出教訓
+awkit lessons stats                # 狀態分布 + 命中/落空率
+awkit lessons add --title ... --content ...   # 手動新增（post-mortem 入口）
+awkit lessons distill [--max N]    # 從新的 review feedback 蒸餾教訓
+awkit lessons promote <L-xxx>      # 為已驗證教訓開一個人審 issue（固化成硬閘門）
+```
+
+### awkit submit-review
+
+提交 PR 審查結果。**推薦**用 `--body-file` 提交結構化 JSON（`StructuredReview`）；schema 錯誤會以退出碼 **2**（`SUBMISSION INVALID`）返回,由同 session 修正,不會浪費一輪 review。舊的 `--body`（markdown）路徑保留相容。
+
+```bash
+awkit submit-review --pr N --issue M --ci-status passed --body-file review.json
+```
+
+---
+
+## 主要子系統（internal/）
+
+| 套件 | 職責 |
+|------|------|
+| `internal/lessons` | 學習迴圈:Store（`.ai/state/lessons.json`）、Select（相關性/注入預算）、Settle（命中/落空狀態機）、Distill（fail-closed LLM 蒸餾） |
+| `internal/reviewer` | 審查管線:`structured.go`（JSON 契約）、`severity.go`（severity/verdict 閘門）、`multi.go`/`secondary.go`/`consensus.go`（multi-model 共識,接進 `submit.go`）、`evidence.go`（證據驗證）、`feedback.go` |
+| `internal/worker` | Worker 執行:`knowledgegraph.go`（Understand-Anything 地圖注入）、`usage.go`（token/成本掃描）、`lessons_inject.go`（教訓注入 + 歸因） |
+| `internal/kickoff` | Principal 啟動器:PTY 執行（Windows ConPTY）、stream-json 解析、`session_usage` 事件 |
+| `internal/trace` | 統一事件流（`.ai/state/events/`），含 `session_usage`（token/成本）|
 
 ---
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -2,11 +2,17 @@
 
 本文件說明 AI Workflow Kit 的內部架構，適用於 Kit 開發者與貢獻者。
 
+> **近期新增子系統（v0.14.0）**：下方部分流程圖早於這些子系統,對整體 Principal→Worker→Reviewer 骨架仍準確,但尚未畫出以下模組。各模組的權威說明見 [API Reference](api-reference.md#主要子系統internal) 與 [Configuration](../user/configuration.md):
+> - **學習迴圈**（`internal/lessons`）:記錄→蒸餾→注入→驗證,教訓存於 `.ai/state/lessons.json`
+> - **結構化 review**（`reviewer/structured.go`）+ **severity/verdict 閘門** + **multi-model 共識**（`reviewer/multi.go`,接進 `submit.go`）
+> - **Knowledge-graph 注入**（`worker/knowledgegraph.go`）與 **token/成本觀測**（`worker/usage.go`、trace `session_usage` 事件）
+> - **原生 Windows 支援**（`kickoff/pty_windows.go` ConPTY）
+
 ---
 
 ## 總覽
 
-AWK 採用 **Sequential Chain** 模式，由 Claude Code (Principal) 協調 Codex (Worker) 執行任務，並使用 GitHub 作為狀態機。
+AWK 採用 **Sequential Chain** 模式，由 Claude Code (Principal) 協調 Worker（`codex` 預設,或 `claude-code`）執行任務，並使用 GitHub 作為狀態機。審查端已從單一 reviewer 演進為結構化提交 + 證據驗證 + 選配的 multi-model 共識。
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -125,13 +131,14 @@ AWK 採用 **Sequential Chain** 模式，由 Claude Code (Principal) 協調 Code
 | 指令 | 說明 |
 |------|------|
 | `awkit init` | 初始化專案 |
-| `awkit kickoff` | 啟動工作流程 |
-| `awkit status` | 檢查工作流程狀態 |
+| `awkit kickoff` | 啟動工作流程（audit/掃描已內建於迴圈） |
+| `awkit status` / `next` | 檢查工作流程狀態 / 下一動作 |
 | `awkit dispatch-worker` | 調度 Worker 執行任務 |
-| `awkit scan-repo` | 掃描專案結構 |
-| `awkit audit-project` | 審計專案狀態 |
+| `awkit submit-review` | 提交審查（`--body-file` 結構化 JSON） |
+| `awkit evaluate` | 評估 gate（`--offline`、`--strict`） |
+| `awkit lessons` | 學習迴圈（list/stats/add/distill/promote） |
 
-詳細用法請參考 `awkit --help` 或專案 README。
+詳細用法請參考 `awkit help` 或專案 README。（註:舊的 `scan-repo` / `audit-project` 子命令已移除,邏輯內建於 `kickoff` 與 `audit-epic`。）
 
 ---
 
@@ -173,9 +180,7 @@ AWK 採用 **Sequential Chain** 模式，由 Claude Code (Principal) 協調 Code
 │                                                              │
 │  [awkit kickoff]                                             │
 │       │                                                      │
-│       ├─► awkit scan-repo ──► analysis/repo_scan.json       │
-│       │                                                      │
-│       ├─► awkit audit-project ──► analysis/audit.json       │
+│       ├─► preflight + audit（內建）                          │
 │       │                                                      │
 │       └─► Claude Code session                                │
 │                 │                                            │

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -362,7 +362,7 @@ go test ./internal/errors -run TestAWKError -v
 ### 測試覆蓋率要求
 
 - 新增的程式碼應有對應的測試
-- 核心套件 (`internal/errors`, `internal/config`) 覆蓋率應 > 70%
+- 核心套件 (`internal/errors`, `internal/analyzer`, `internal/reviewer`, `internal/worker`) 覆蓋率應 > 70%
 - PR 不應降低整體覆蓋率
 
 ---

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -438,48 +438,23 @@ def test_with_fixture_file(fixtures_dir):
 
 ### GitHub Actions
 
-> ⚠️ **已棄用**: 以下 Python/pytest CI 配置已棄用。目前 CI 使用 Go 測試。
+實際 CI 定義於 `.github/workflows/ci.yml`,共四個 job:
 
-```yaml
-# .github/workflows/test.yml (已棄用 - 僅供參考)
-name: Test
+| Job | Runner | 內容 |
+|-----|--------|------|
+| `awkit_cli` | ubuntu-latest | `go vet`、`go test -race -coverprofile`（**60% 覆蓋率門檻閘門**）、`awkit evaluate --offline` 與 `--offline --strict`、上傳覆蓋率 artifact |
+| `awkit_cli_windows` | **windows-latest** | 完整 `go test ./...` 套件,守護原生 path / ConPTY / process 行為（先關 autocrlf、把 Git Bash 加入 PATH） |
+| `backend` | ubuntu-latest | 在 `backend/` 跑 `go test -race ./...` |
+| `frontend` | ubuntu-latest | `frontend/Packages/manifest.json` JSON 驗證 + 資料夾檢查 |
 
-on: [push, pull_request]
-
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install dependencies
-        run: |
-          pip install pytest pytest-cov pyyaml jsonschema jinja2
-
-      - name: Run tests
-        run: |
-          python -m pytest .ai/tests/unit -v --tb=short
-
-      - name: Coverage report
-        run: |
-          # DEPRECATED: .ai/scripts/ has been removed. Use Go test coverage instead.
-          # python -m pytest .ai/tests/unit --cov=.ai/scripts --cov-report=term-missing
-          go test ./... -cover
-```
+> Windows job 是刻意的跨平台守門:kit 出貨 `awkit.exe`、`install.ps1` 與 ConPTY-based 的 Principal runner,只跑 Linux 曾累積過一批 Windows-only 的失敗。race 偵測器跑在 Linux job(`-race` 需要 cgo)。
 
 ### 本地 CI 模擬
 
 ```bash
-# 執行 Go 測試 (推薦)
-go test ./... -v
-
-# (已棄用) 執行 Python 測試
-# python3 -m pytest .ai/tests/unit -v --tb=short
+go vet ./...
+go test -race ./...          # 需 cgo（CGO_ENABLED=1）
+awkit evaluate --offline --strict
 ```
 
 ---

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -7,7 +7,7 @@
 ## 配置檔結構
 
 ```yaml
-version: "1.1"
+version: "1.2"
 project: { ... }
 repos: [ ... ]
 git: { ... }
@@ -16,9 +16,14 @@ tasks: { ... }
 audit: { ... }
 github: { ... }
 rules: { ... }
-escalation: { ... }
+agents: { ... }
 timeouts: { ... }
+escalation: { ... }
 review: { ... }
+feedback: { ... }
+lessons: { ... }
+hooks: { ... }
+worker: { ... }
 # notifications: (planned for future release)
 ```
 
@@ -62,6 +67,7 @@ repos:
 | `path` | 是 | 相對於專案根目錄的路徑 |
 | `type` | 是 | `root` / `directory` / `submodule` |
 | `language` | 是 | 程式語言 (影響 CI 模板) |
+| `verify.setup` | 否 | 建置/測試前的依賴安裝指令（未設定時依 language/package_manager 自動推斷,如 `npm ci`、`pip install -r requirements.txt`） |
 | `verify.build` | 是 | 建置指令 |
 | `verify.test` | 是 | 測試指令 |
 
@@ -209,12 +215,24 @@ github:
     pr_ready: "pr-ready"
     review_failed: "review-failed"
     worker_failed: "worker-failed"
+    needs_human_review: "needs-human-review"
+    merge_conflict: "merge-conflict"
+    needs_rebase: "needs-rebase"
+    completed: "completed"
 ```
 
 | 欄位 | 說明 |
 |------|------|
 | `repo` | GitHub repo (owner/name)，空白則自動偵測 |
-| `labels` | Issue/PR 使用的標籤 |
+| `labels.task` | 待處理任務 |
+| `labels.in_progress` | 已派工執行中 |
+| `labels.pr_ready` | Worker 完成、PR 待審 |
+| `labels.review_failed` | 審查/驗證失敗,待重審 |
+| `labels.worker_failed` | Worker 失敗,需人工介入 |
+| `labels.needs_human_review` | 超過重試上限,需人工審查 |
+| `labels.merge_conflict` | PR 有合併衝突 |
+| `labels.needs_rebase` | PR 落後 base,需 rebase |
+| `labels.completed` | 完成（success_no_changes） |
 
 ---
 
@@ -245,6 +263,31 @@ rules:
   custom:
     - backend-go
 ```
+
+---
+
+## agents - Agent 設定
+
+```yaml
+agents:
+  builtin:
+    - pr-reviewer           # PR 審查 agent
+    - conflict-resolver     # 合併衝突解決 agent
+  custom: []                # 自訂 subagent
+```
+
+`builtin` 為 kit 內建 agent（由 `awkit generate` 管理）。`custom` 可定義額外 subagent,每個會在 `awkit generate` 時生成到 `.claude/agents/`。
+
+自訂 agent 欄位：
+
+| 欄位 | 說明 |
+|------|------|
+| `name` | Agent 名稱（小寫字母、數字、連字號） |
+| `description` | 描述（必填） |
+| `tools` | 允許的工具（預設 `Read, Grep, Glob, Bash`） |
+| `model` | `haiku` \| `sonnet` \| `opus`（預設 `opus`） |
+| `trigger` | `review_pr` \| `check_result` \| `dispatch_worker` \| `generate_tasks` |
+| `condition` | 觸發條件表達式 |
 
 ---
 
@@ -304,16 +347,130 @@ timeouts:
 
 ```yaml
 review:
-  score_threshold: 7       # PR 審核通過的最低分數（1-10）
-  merge_strategy: squash   # 合併策略：squash | merge | rebase
+  score_threshold: 7           # PR 審核通過的最低分數（1-10）
+  merge_strategy: squash       # 合併策略：squash | merge | rebase
+  severity_consistency: true   # severity/verdict 一致性閘門（預設開）
+  multi_model: false           # multi-model 共識審查
+  # secondary_reviewers:
+  #   - backend: claude
+  #     model: opus
+  #     focus_area: architecture
+  # jittest:
+  #   enabled: false
+  #   max_tests: 5
+  #   timeout_seconds: 120
+  #   failure_policy: warn      # warn | block
 ```
 
 Principal 審查 Worker 提交的 PR 時使用的設定。
 
 | 欄位 | 預設值 | 說明 |
 |------|--------|------|
-| `score_threshold` | `7` | PR 審核通過的最低分數（範圍 1-10）。Reviewer 給予的分數必須 >= 此值才會 approve PR |
-| `merge_strategy` | `squash` | PR 通過審核後的合併方式。可選值：`squash`（壓縮合併）、`merge`（一般合併）、`rebase`（變基合併） |
+| `score_threshold` | `7` | 審核通過的最低分數（1-10）。分數必須 >= 此值才 approve |
+| `merge_strategy` | `squash` | 合併方式：`squash` / `merge` / `rebase` |
+| `severity_consistency` | `true` | 一致性閘門：低於門檻的分數必須列出 >=1 個 Critical/Important 發現;達門檻的分數不得有 Critical 發現。不符則 `review_blocked` |
+| `multi_model` | `false` | 開啟後,`submit-review` 取 PR diff、平行執行次要審查者,套用加權共識（primary×0.7 + secondaries 均分 0.3），任一審查者回報 `[ERROR]` 時共識分數上限 6 |
+| `secondary_reviewers[]` | — | 次要審查者清單,每項 `{backend, model, focus_area}`。省略時預設一個 architecture-focused opus 審查者 |
+| `jittest` | 停用 | 審查時從 PR diff 生成獨立測試（`awkit jittest`）。`failure_policy: block` 時失敗會 `review_blocked` |
+
+---
+
+## feedback - 審查回饋設定
+
+```yaml
+feedback:
+  enabled: true               # 記錄審查拒絕並注入 Worker prompt
+  max_history_in_prompt: 10   # 注入 Worker prompt 的最大歷史筆數
+```
+
+Review 拒絕會被記錄到 `.ai/state/review_feedback.jsonl`,並將 top rejection categories 注入後續 Worker prompt。此系統也是[學習迴圈](#lessons---學習迴圈設定)的資料來源。
+
+| 欄位 | 預設值 | 說明 |
+|------|--------|------|
+| `enabled` | `true` | 是否記錄與注入 feedback |
+| `max_history_in_prompt` | `10` | 注入 prompt 的最大歷史筆數 |
+
+---
+
+## lessons - 學習迴圈設定
+
+```yaml
+lessons:
+  enabled: true               # 學習迴圈總開關
+  max_active: 30              # active+proven 教訓上限
+  inject_top_k: 3             # 每個 prompt 注入的教訓數上限
+  inject_max_chars: 800       # 注入區段的字元上限
+  distiller:
+    backend: claude           # 蒸餾器後端（claude --print）
+    model: sonnet
+    timeout_seconds: 60
+```
+
+學習迴圈:審查拒絕經 LLM 蒸餾成精簡教訓（存於可提交的 `.ai/state/lessons.json`），注入後續 Worker/Reviewer prompt,並依 PR 結果結算命中/落空。已驗證（proven）的教訓可用 `awkit lessons promote <id>` 開一個人審 issue,固化成硬閘門。
+
+指令:`awkit lessons list | stats | add | distill | promote`。
+
+| 欄位 | 預設值 | 說明 |
+|------|--------|------|
+| `enabled` | `true` | 關閉後仍會記錄 feedback,但不注入/蒸餾教訓 |
+| `max_active` | `30` | active+proven 教訓上限,超過時淘汰分數最低者 |
+| `inject_top_k` | `3` | 每個 prompt 注入的教訓數上限（小 k 較佳） |
+| `inject_max_chars` | `800` | 注入區段的硬字元上限 |
+| `distiller.backend` | `claude` | 蒸餾器後端 |
+| `distiller.model` | `sonnet` | 蒸餾器模型 |
+| `distiller.timeout_seconds` | `60` | 蒸餾單筆的逾時 |
+
+---
+
+## hooks - 生命週期 Hook
+
+```yaml
+hooks:
+  pre_dispatch:
+    - command: "echo dispatching issue $AWK_ISSUE"
+      timeout: "30s"
+      on_failure: warn        # warn（預設）| abort | ignore
+  on_merge:
+    - command: "curl -X POST $SLACK_WEBHOOK -d '{\"text\": \"PR merged\"}'"
+      timeout: "10s"
+      on_failure: ignore
+```
+
+在工作流事件執行自訂 shell 命令。事件:`pre_dispatch`、`post_dispatch`、`pre_review`、`post_review`、`on_merge`、`on_failure`。
+
+| 欄位 | 說明 |
+|------|------|
+| `command` | 要執行的 shell 命令 |
+| `timeout` | 逾時（如 `30s`，經 `time.ParseDuration`） |
+| `on_failure` | `warn`（預設，記錄）\| `abort`（中止工作流）\| `ignore` |
+| `env` | 額外環境變數 |
+
+---
+
+## worker - Worker 設定
+
+```yaml
+worker:
+  backend: codex              # codex（預設）| claude-code
+  knowledge_graph: auto       # auto（存在時注入）| off
+  # codex:
+  #   full_auto: true
+  #   max_attempts: 1
+  # claude_code:
+  #   model: sonnet
+  #   max_turns: 50
+  #   dangerously_skip_permissions: false
+```
+
+| 欄位 | 預設值 | 說明 |
+|------|--------|------|
+| `backend` | `codex` | Worker 後端:`codex` 或 `claude-code` |
+| `knowledge_graph` | `auto` | 當 `.understand-anything/knowledge-graph.json` 存在時,把票券相關的程式碼地圖切片注入 Worker prompt;`off` 停用 |
+| `codex.full_auto` | `true` | codex 使用 `--full-auto` |
+| `codex.max_attempts` | `1` | codex 層級的重試次數 |
+| `claude_code.model` | `sonnet` | claude-code Worker 的模型 |
+| `claude_code.max_turns` | `50` | claude-code 的最大回合數 |
+| `claude_code.dangerously_skip_permissions` | `false` | 是否跳過權限確認 |
 
 ---
 
@@ -335,7 +492,7 @@ Slack/Discord webhook notifications are defined in the configuration schema but 
 ### Single-Repo (Python)
 
 ```yaml
-version: "1.1"
+version: "1.2"
 
 project:
   name: "my-python-app"
@@ -375,7 +532,7 @@ escalation:
 ### Monorepo (Go + React)
 
 ```yaml
-version: "1.1"
+version: "1.2"
 
 project:
   name: "fullstack-app"
@@ -455,13 +612,26 @@ awkit doctor
 
 ### 手動遷移
 
-如果需要手動遷移，以下是 v1.0 → v1.1 的變更清單：
+通常執行 `awkit upgrade` 即可自動遷移。以下為各版本的主要變更。
+
+**v1.0 → v1.1：**
 
 1. **Label 值修正**：`review_failed: "review-fail"` → `review_failed: "review-failed"`
 2. **新增 labels**：`merge_conflict`、`needs_rebase`、`completed`
 3. **新增 timeout 欄位**：`gh_retry_count`、`gh_retry_base_delay`
 4. **新增 review section**：`score_threshold`、`merge_strategy`
 5. **版本號更新**：`version: "1.0"` → `version: "1.1"`
+
+**v1.1 → v1.2：**
+
+1. **新增 `agents` section**：`builtin`（pr-reviewer、conflict-resolver）+ `custom`
+2. **新增 `feedback` section**：`enabled`、`max_history_in_prompt`
+3. **新增 `lessons` section**（學習迴圈）：`enabled`、`max_active`、`inject_top_k`、`inject_max_chars`、`distiller.*`
+4. **新增 `hooks` section**：生命週期 shell 命令
+5. **新增 `worker` section**：`backend`（codex/claude-code）、`knowledge_graph`、`codex.*`、`claude_code.*`
+6. **擴充 `review`**：`severity_consistency`、`multi_model`、`secondary_reviewers[]`、`jittest.*`
+7. **新增 `verify.setup`**：建置前依賴安裝
+8. **版本號更新**：`version: "1.1"` → `version: "1.2"`
 
 ### 備份
 

--- a/docs/user/faq.md
+++ b/docs/user/faq.md
@@ -126,7 +126,7 @@ Coordination: sequential
 
 **A:**
 - **Principal (Claude Code)** - 讀取 spec、建立 Issue、審查 PR、決策
-- **Worker (Codex)** - 實作程式碼、提交 PR
+- **Worker** - 實作程式碼、提交 PR。後端可選 `codex`（預設）或 `claude-code`，由 `worker.backend` 設定
 
 ---
 
@@ -186,7 +186,7 @@ rules:
 
 ### Q: 如何查看執行日誌？
 
-**A:** 日誌存放在 `.ai/logs/` 目錄，使用 `--log-level debug` 可獲得更詳細的輸出。
+**A:** 日誌存放在 `.ai/exe-logs/` 目錄（`principal.log` 與 `issue-{N}.worker.log`）。結構化事件流在 `.ai/state/events/`，可用 `awkit events` 查詢。
 
 ---
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -278,7 +278,9 @@ brew install bash
 | `awkit validate` | 驗證配置 |
 | `awkit doctor` | 檢查專案健康狀態，報告問題 |
 | `awkit reset` | 重設專案狀態（支援 `--all`、`--dry-run` 等 flags） |
-| `awkit evaluate` | 執行品質評估（離線/線上 gate 檢查與評分） |
+| `awkit generate` | 生成輔助文件與 scaffolding |
+| `awkit evaluate` | 執行品質評估（離線/線上 gate 檢查與評分；`--offline`、`--strict`） |
+| `awkit lessons` | 學習迴圈：`list` / `stats` / `add` / `distill` / `promote` |
 
 ### init 選項
 

--- a/docs/user/quick-start.md
+++ b/docs/user/quick-start.md
@@ -13,6 +13,7 @@ Install these **before** anything else:
 | **GitHub CLI (`gh`)** | [cli.github.com](https://cli.github.com/) | Issue/PR operations (required) |
 | **`gh auth login`** | Run after installing `gh` | **#1 first-time blocker** — authenticate now |
 | **Claude Code (`claude`)** | [claude.ai/download](https://claude.ai/download) | Principal AI agent |
+| **Codex (`codex`)** | per Codex docs | Default Worker backend (`worker.backend: codex`) — needed for `kickoff` to dispatch work; skip if you set `worker.backend: claude-code` |
 | **Git** | [git-scm.com](https://git-scm.com/) | Version control |
 
 ```bash

--- a/docs/user/skills.md
+++ b/docs/user/skills.md
@@ -90,6 +90,27 @@ Principal Agent 的主工作流程。
 
 ---
 
+### `/post-mortem`
+
+任務失敗後的結構化事後分析（唯讀）。
+
+**用途：**
+- 分析 Worker/Review 失敗的根因
+- 是[學習迴圈](configuration.md#lessons---學習迴圈設定)的手動入口 —— 分析出的教訓可用 `awkit lessons add` 記錄
+
+---
+
+### `/release-checklist`
+
+發布前的 go/no-go 驗證。
+
+**用途：**
+- 在合併整合分支到 `main`、打 release tag 前執行
+- 檢查測試、未提交變更、依賴、CI 狀態、分支與 main 的落差
+- 產出明確的 GO / NO-GO 決策（僅驗證,不會自動修復或合併）
+
+---
+
 ## Skills 結構
 
 每個 Skill 由以下檔案組成：

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -620,16 +620,19 @@ API rate limit exceeded
 awkit validate
 ```
 
-### 掃描專案狀態
+### 查看工作流狀態
 
 ```bash
-awkit scan-repo
+awkit status        # 離線狀態摘要
+awkit next          # 顯示下一個動作
+awkit analyze-next --json   # 完整狀態機決策（JSON）
 ```
 
-### 執行審計
+### 查看學習迴圈教訓
 
 ```bash
-awkit audit-project
+awkit lessons list
+awkit lessons stats
 ```
 
 ---


### PR DESCRIPTION
Documentation had drifted well behind the code (roughly v0.13.0). Full pass across README (both languages) and docs/.

README.md + README-zh-TW.md:
- Features: added review-quality (structured submission, evidence gate, multi-model consensus, severity gate, JiT), learning loop, context grounding (design-doc + knowledge-graph), Windows, token/cost, hooks, worker-backend selection
- Config: added a sections overview table + highlighted new review/worker/ lessons keys (full reference points to configuration.md)
- CI: documented all four jobs incl. the windows-latest job, vet, race, 60 percent coverage gate
- Tech stack: fixed the stale python "legacy scripts" rationale; noted worker-backend requirements and native Windows/ConPTY
- Docs index: added skills.md; zh-TW gained the missing Quick Start row and the offline/strict evaluate forms

docs/user/configuration.md (was the most stale config reference):
- version 1.1 to 1.2 throughout; structure block lists all sections
- added the missing sections: agents, feedback, lessons, hooks, worker
- expanded review (multi_model, secondary_reviewers, severity_consistency, jittest); completed github.labels; added verify.setup; v1.1-to-v1.2 migration notes

docs/user/: faq (.ai/logs to .ai/exe-logs, worker backend), troubleshooting (replaced non-existent scan-repo/audit-project with status/next/lessons), skills (added post-mortem + release-checklist), quick-start (Codex prereq), getting-started (lessons/generate in CLI table)

docs/developer/: api-reference (removed non-existent scan-repo/audit-project, added lessons/evaluate/submit-review + an internal subsystems table), testing (real four-job CI incl. windows, replacing the deprecated pytest workflow), contributing (fixed non-existent internal/config), architecture
+ ai-workflow-architecture (honest "diagrams predate these subsystems" notes; fixed the command table and data-flow diagram).

All documented config keys verified against internal struct tags; new doc-to-doc anchors verified against their headings.