### PR TITLE
[fix] stop updatecheck tests from polluting the real user cache

### DIFF
--- a/internal/updatecheck/check.go
+++ b/internal/updatecheck/check.go
@@ -136,7 +136,16 @@ func writeCache(entry cacheEntry) {
 	_ = os.WriteFile(path, data, 0o644)
 }
 
+// cacheDirEnv lets callers relocate the update-check cache. When set, the
+// cache file is <AWKIT_CACHE_DIR>/update.json. Tests set it to a temp dir so
+// they never write to the real user cache (which previously leaked a fake
+// "v1.0.0" into every developer's machine).
+const cacheDirEnv = "AWKIT_CACHE_DIR"
+
 func cachePath() (string, error) {
+	if override := os.Getenv(cacheDirEnv); override != "" {
+		return filepath.Join(override, "update.json"), nil
+	}
 	dir, err := os.UserCacheDir()
 	if err != nil || dir == "" {
 		home, err := os.UserHomeDir()

--- a/internal/updatecheck/check_extra_test.go
+++ b/internal/updatecheck/check_extra_test.go
@@ -25,6 +25,30 @@ func TestCachePath_ReturnsNonEmptyPath(t *testing.T) {
 	}
 }
 
+// TestCachePath_HonorsEnvOverride locks in the isolation fix: when
+// AWKIT_CACHE_DIR is set, the cache file lives under it (never the real user
+// cache dir). This is what keeps the whole package's tests from polluting a
+// developer's machine.
+func TestCachePath_HonorsEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(cacheDirEnv, dir)
+
+	p, err := cachePath()
+	if err != nil {
+		t.Fatalf("cachePath() error = %v", err)
+	}
+	want := filepath.Join(dir, "update.json")
+	if p != want {
+		t.Errorf("cachePath() = %q, want %q", p, want)
+	}
+
+	// A real writeCache must land in the override dir, not the user cache.
+	writeCache(cacheEntry{Latest: "v9.9.9", CheckedAt: time.Now()})
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("writeCache did not write to the override path: %v", err)
+	}
+}
+
 // --- readCache / writeCache round-trip ---
 
 func TestReadWriteCache_RoundTrip(t *testing.T) {
@@ -258,9 +282,9 @@ func TestCheck_NetworkError(t *testing.T) {
 // --- writeCache does not panic on error ---
 
 func TestWriteCache_NocrashOnBadPath(t *testing.T) {
-	// writeCache is best-effort; verify it doesn't panic
-	// We rely on the real writeCache which uses the system cache dir.
-	// Just call it and ensure no panic.
+	// writeCache is best-effort; verify it doesn't panic. The package's
+	// TestMain redirects AWKIT_CACHE_DIR to a temp dir, so this writes there,
+	// not to the real user cache.
 	entry := cacheEntry{Latest: "v1.0.0", CheckedAt: time.Now()}
 	defer func() {
 		if r := recover(); r != nil {

--- a/internal/updatecheck/main_test.go
+++ b/internal/updatecheck/main_test.go
@@ -1,0 +1,24 @@
+package updatecheck
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain isolates every test in this package from the real user cache dir by
+// pointing AWKIT_CACHE_DIR at a throwaway temp directory. Without this, tests
+// that call writeCache/Check wrote to the actual ~/.cache/awkit/update.json —
+// leaking a fake "v1.0.0" that made every developer's awkit report a bogus
+// "update available".
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "awkit-updatecheck-cache-*")
+	if err != nil {
+		panic("updatecheck test setup: " + err.Error())
+	}
+	_ = os.Setenv(cacheDirEnv, dir)
+
+	code := m.Run()
+
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}


### PR DESCRIPTION
The updatecheck tests called the real writeCache/Check, which writes to os.UserCacheDir()/awkit/update.json. TestWriteCache_NocrashOnBadPath in particular wrote {"latest":"v1.0.0"} into every developer's actual cache, so `awkit version` then reported a bogus "update available: -> v1.0.0" (no such release exists) until the 24h TTL expired.

Fix: cachePath() now honors an AWKIT_CACHE_DIR override, and a package TestMain points it at a throwaway temp dir so no test can touch the real cache. Verified: after `go test ./internal/updatecheck/...`, the real ~/.cache/awkit/update.json is not created. Added
TestCachePath_HonorsEnvOverride to lock the behavior in.

AWKIT_CACHE_DIR also doubles as a legit user override for the cache location.