### PR TITLE
[fix] create the workflow's state-machine labels at kickoff

### DIFF
--- a/cmd/awkit/kickoff.go
+++ b/cmd/awkit/kickoff.go
@@ -19,6 +19,7 @@ import (
 	"github.com/silver2dream/ai-workflow-kit/internal/kickoff"
 	"github.com/silver2dream/ai-workflow-kit/internal/session"
 	"github.com/silver2dream/ai-workflow-kit/internal/trace"
+	"github.com/silver2dream/ai-workflow-kit/internal/worker"
 )
 
 func usageKickoff() {
@@ -237,6 +238,12 @@ func cmdKickoff(args []string) int {
 			"project": config.Project.Name,
 			"session": principalSessionID,
 		}))
+
+	// Ensure the workflow's state-machine labels exist before the Principal
+	// starts. The worker and reviewer add/remove these as issues move through the
+	// pipeline; if they're missing, every `gh issue edit` logs a noisy
+	// '<label> not found'. Best-effort — a permission failure is just a warning.
+	ensureWorkflowLabels(configPath, output)
 
 	// Build Claude CLI command
 	// Use stream-json format for real-time streaming output
@@ -852,6 +859,36 @@ func formatAnalyzeNextContext(v analyzeNextVars) string {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// ensureWorkflowLabels creates the state-machine labels up front so the worker
+// and reviewer don't spam '<label> not found' as they move issues through the
+// pipeline. Best-effort: config/permission problems are a warning, not a blocker.
+func ensureWorkflowLabels(configPath string, output *kickoff.OutputFormatter) {
+	cfg, err := analyzer.LoadConfig(configPath)
+	if err != nil {
+		return // config errors are surfaced by preflight already
+	}
+	ghc := worker.NewGitHubClient(30 * time.Second)
+	if err := ghc.EnsureLabels(context.Background(), cfg.GitHub.Repo, workflowLabelSpecs(cfg.GitHub.Labels)); err != nil {
+		output.Warning(fmt.Sprintf("Some workflow labels could not be created: %v", err))
+	}
+}
+
+// workflowLabelSpecs maps the configured label names to create specs with stable
+// colors and descriptions.
+func workflowLabelSpecs(l analyzer.LabelsConfig) []worker.LabelSpec {
+	return []worker.LabelSpec{
+		{Name: l.Task, Color: "1d76db", Description: "AWK automated task"},
+		{Name: l.InProgress, Color: "fbca04", Description: "Worker is implementing this issue"},
+		{Name: l.PRReady, Color: "0e8a16", Description: "PR is ready for review"},
+		{Name: l.WorkerFailed, Color: "d93f0b", Description: "Worker failed after retries"},
+		{Name: l.NeedsHumanReview, Color: "d876e3", Description: "Needs human review"},
+		{Name: l.ReviewFailed, Color: "b60205", Description: "Automated review failed"},
+		{Name: l.MergeConflict, Color: "e99695", Description: "PR has merge conflicts"},
+		{Name: l.NeedsRebase, Color: "c2e0c6", Description: "Branch needs rebase before merge"},
+		{Name: l.Completed, Color: "5319e7", Description: "Task completed"},
+	}
 }
 
 func getEnvInt(name string, defaultValue int) int {

--- a/cmd/awkit/kickoff_test.go
+++ b/cmd/awkit/kickoff_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"testing"
+
+	"github.com/silver2dream/ai-workflow-kit/internal/analyzer"
+	"github.com/silver2dream/ai-workflow-kit/internal/worker"
 )
 
 func TestExtractTextFromStreamJSON(t *testing.T) {
@@ -161,6 +164,37 @@ func TestGetEnvString(t *testing.T) {
 	// An unset variable returns the default.
 	if got := getEnvString("AWKIT_DEFINITELY_UNSET_KEY", "auto"); got != "auto" {
 		t.Errorf("unset env: got %q, want auto", got)
+	}
+}
+
+func TestWorkflowLabelSpecs(t *testing.T) {
+	labels := analyzer.DefaultLabels()
+	specs := workflowLabelSpecs(labels)
+
+	byName := make(map[string]worker.LabelSpec, len(specs))
+	for _, s := range specs {
+		byName[s.Name] = s
+	}
+
+	// Every state-machine label the workflow relies on must have a spec, or it
+	// won't be created and gh edits against it will fail with 'not found'.
+	want := []string{
+		labels.Task, labels.InProgress, labels.PRReady, labels.WorkerFailed,
+		labels.NeedsHumanReview, labels.ReviewFailed, labels.MergeConflict,
+		labels.NeedsRebase, labels.Completed,
+	}
+	for _, name := range want {
+		s, ok := byName[name]
+		if !ok {
+			t.Errorf("label %q has no spec", name)
+			continue
+		}
+		if len(s.Color) != 6 {
+			t.Errorf("label %q color %q must be 6-hex", name, s.Color)
+		}
+		if s.Description == "" {
+			t.Errorf("label %q has an empty description", name)
+		}
 	}
 }
 

--- a/internal/worker/github.go
+++ b/internal/worker/github.go
@@ -132,6 +132,48 @@ func (c *GitHubClient) RemoveLabel(ctx context.Context, number int, label string
 	return c.EditIssueLabels(ctx, number, nil, []string{label})
 }
 
+// LabelSpec describes a repository label to ensure exists.
+type LabelSpec struct {
+	Name        string
+	Color       string // 6-hex, no leading '#'; empty lets gh pick one
+	Description string
+}
+
+// EnsureLabels creates each label, updating an existing one's color/description
+// (`gh label create --force` is an upsert). It is best-effort and idempotent: a
+// failure on one label is collected and reported but does not stop the others,
+// so a permission error surfaces without aborting the workflow. Labels with an
+// empty Name are skipped.
+func (c *GitHubClient) EnsureLabels(ctx context.Context, repo string, specs []LabelSpec) error {
+	var failed []string
+	for _, s := range specs {
+		if strings.TrimSpace(s.Name) == "" {
+			continue
+		}
+		args := []string{"label", "create", s.Name, "--force"}
+		if s.Color != "" {
+			args = append(args, "--color", s.Color)
+		}
+		if s.Description != "" {
+			args = append(args, "--description", s.Description)
+		}
+		if repo != "" {
+			args = append(args, "--repo", repo)
+		}
+
+		lctx, cancel := context.WithTimeout(ctx, c.Timeout)
+		out, err := ghutil.RunWithRetry(lctx, c.Retry, "gh", args...)
+		cancel()
+		if err != nil {
+			failed = append(failed, fmt.Sprintf("%s (%s)", s.Name, strings.TrimSpace(string(out))))
+		}
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("could not ensure %d label(s): %s", len(failed), strings.Join(failed, "; "))
+	}
+	return nil
+}
+
 // CommentOnIssue adds a comment to an issue
 func (c *GitHubClient) CommentOnIssue(ctx context.Context, number int, body string) error {
 	ctx, cancel := context.WithTimeout(ctx, c.Timeout)


### PR DESCRIPTION
The pipeline drives issues with labels (in-progress, pr-ready, completed, worker-failed, ...), but nothing created them, so on a fresh repo every worker and reviewer step logged 'gh issue edit failed: <label> not found'. Only ai-task happened to get created (by the skill).

Ensure all configured labels up front in `awkit kickoff` via a new GitHubClient.EnsureLabels (idempotent `gh label create --force` upsert, best-effort — a permission failure is a warning, not a blocker). Colors and descriptions are stable; names come from config so custom label names are honoured.

Tests: workflowLabelSpecs covers every configured label with a valid 6-hex color and description.