### PR TITLE
[fix] stop the kickoff loop from spinning forever on a stalled creati…

### DIFF
--- a/cmd/awkit/kickoff.go
+++ b/cmd/awkit/kickoff.go
@@ -517,6 +517,15 @@ func cmdKickoff(args []string) int {
 	signalHandler.Setup()
 
 	var lastNext analyzeNextVars
+	// No-progress guard: a "creation" decision (create_task/generate_tasks/
+	// audit_epic) always changes repo state on success, so if the analyzer keeps
+	// returning the exact same one, the workflow is stalled — classically a
+	// create_task whose `gh issue create` fails on a permission error, which is
+	// invisible to the analyzer (it only sees that the issue still doesn't
+	// exist) and never counts as a consecutive_failure. Count identical repeats
+	// so we can stop with a clear message instead of burning every session.
+	var sameDecisionStreak int
+	maxSameDecision := getEnvInt("AWKIT_MAX_SAME_DECISION", 3)
 
 	for sessionIndex := 1; sessionIndex <= maxSessions; sessionIndex++ {
 		// Write loop_start event
@@ -584,6 +593,11 @@ func cmdKickoff(args []string) int {
 			endPrincipalSession("paused")
 			return 1
 		}
+		if sessionIndex > 1 && sameDecision(next, lastNext) {
+			sameDecisionStreak++
+		} else {
+			sameDecisionStreak = 1
+		}
 		lastNext = next
 
 		// Write loop_decision event
@@ -624,6 +638,13 @@ func cmdKickoff(args []string) int {
 			endPrincipalSession("stopped")
 			return 1
 		default:
+			if isCreationAction(next.NextAction) && sameDecisionStreak >= maxSameDecision {
+				fmt.Println("")
+				output.Error(fmt.Sprintf("Workflow stopped: no progress — '%s'%s repeated %d× without advancing.", next.NextAction, formatAnalyzeNextContext(next), sameDecisionStreak))
+				output.Info("This usually means gh lacks write access to the repo (check `gh auth status` and the repo's permissions) or a label/config problem. See `awkit doctor`.")
+				endPrincipalSession("no_progress")
+				return 1
+			}
 			output.Info(fmt.Sprintf("Pending: %s%s (restarting in %s)", next.NextAction, formatAnalyzeNextContext(next), restartDelay))
 			time.Sleep(restartDelay)
 			// G8 fix: exponential backoff - double delay for next restart, capped at max
@@ -854,6 +875,32 @@ func formatAnalyzeNextContext(v analyzeNextVars) string {
 		return ""
 	}
 	return " (" + strings.Join(parts, " ") + ")"
+}
+
+// sameDecision reports whether two analyze-next results are identical across
+// every field that identifies the work to be done. Used to detect a stalled
+// loop that keeps deciding the same thing without making progress.
+func sameDecision(a, b analyzeNextVars) bool {
+	return a.NextAction == b.NextAction &&
+		a.IssueNumber == b.IssueNumber &&
+		a.PRNumber == b.PRNumber &&
+		a.SpecName == b.SpecName &&
+		a.TaskLine == b.TaskLine &&
+		a.MergeIssue == b.MergeIssue
+}
+
+// isCreationAction reports whether an action creates GitHub state (an issue or
+// task list) that, on success, necessarily advances the workflow. Repeating one
+// of these unchanged is a hard stall, so the no-progress guard only trips on
+// them — actions like check_result or dispatch_worker can legitimately recur
+// while a worker runs.
+func isCreationAction(action string) bool {
+	switch action {
+	case "create_task", "generate_tasks", "audit_epic":
+		return true
+	default:
+		return false
+	}
 }
 
 func fileExists(path string) bool {

--- a/cmd/awkit/kickoff_test.go
+++ b/cmd/awkit/kickoff_test.go
@@ -198,6 +198,40 @@ func TestWorkflowLabelSpecs(t *testing.T) {
 	}
 }
 
+func TestSameDecision(t *testing.T) {
+	base := analyzeNextVars{NextAction: "create_task", SpecName: "tennis-arena", TaskLine: "15"}
+
+	if !sameDecision(base, analyzeNextVars{NextAction: "create_task", SpecName: "tennis-arena", TaskLine: "15"}) {
+		t.Error("identical decisions should compare equal")
+	}
+
+	// Any single differing field breaks equality.
+	diffs := map[string]analyzeNextVars{
+		"action": {NextAction: "dispatch_worker", SpecName: "tennis-arena", TaskLine: "15"},
+		"line":   {NextAction: "create_task", SpecName: "tennis-arena", TaskLine: "16"},
+		"spec":   {NextAction: "create_task", SpecName: "other", TaskLine: "15"},
+		"issue":  {NextAction: "create_task", SpecName: "tennis-arena", TaskLine: "15", IssueNumber: "7"},
+	}
+	for name, d := range diffs {
+		if sameDecision(base, d) {
+			t.Errorf("differing %s should not compare equal", name)
+		}
+	}
+}
+
+func TestIsCreationAction(t *testing.T) {
+	for _, a := range []string{"create_task", "generate_tasks", "audit_epic"} {
+		if !isCreationAction(a) {
+			t.Errorf("%q should be a creation action", a)
+		}
+	}
+	for _, a := range []string{"dispatch_worker", "check_result", "review_pr", "all_complete", "none", ""} {
+		if isCreationAction(a) {
+			t.Errorf("%q should not be a creation action", a)
+		}
+	}
+}
+
 func TestParseAnalyzeNextOutput(t *testing.T) {
 	out := `
 NEXT_ACTION=create_task


### PR DESCRIPTION
…on action

When `awkit create-task` fails (e.g. `gh issue create` hits a 403 because the token lacks write access to the repo), the failure is invisible to the analyzer: it only sees that the issue still doesn't exist, so it returns create_task again, every session, forever — up to maxSessions (50), each costing a full Claude session. create_task failures never increment consecutive_failures (that path is driven by the worker/dispatch flow), so the existing safety net never trips. Observed: 5 sessions of pure spin before the user hit Ctrl+C.

Add a no-progress guard to the multi-session loop: if the analyzer returns the exact same *creation* decision (create_task / generate_tasks / audit_epic) AWKIT_MAX_SAME_DECISION times running (default 3), stop with a clear message pointing at the likely cause (gh write permission / label / config). Creation actions always change repo state on success, so an identical repeat is a hard stall with zero false positives; check_result / dispatch_worker, which can legitimately recur while a worker runs, are deliberately left untouched.

Tests: sameDecision (field-by-field equality) and isCreationAction.