### PR TITLE
[fix] collapse [EXEC] console output to one bounded line

### DIFF
--- a/cmd/awkit/kickoff.go
+++ b/cmd/awkit/kickoff.go
@@ -688,6 +688,21 @@ func sanitizeStreamLine(line string) string {
 	return strings.TrimSpace(line)
 }
 
+// summarizeCommand collapses a shell command to a single length-bounded line for
+// [EXEC] display. Without it a multi-line command — e.g. a reviewer heredoc that
+// inlines an entire review body — dumps hundreds of lines to the console.
+func summarizeCommand(cmd string) string {
+	cmd = strings.TrimSpace(cmd)
+	if i := strings.IndexAny(cmd, "\r\n"); i >= 0 {
+		cmd = strings.TrimSpace(cmd[:i]) + " …"
+	}
+	const maxRunes = 200
+	if r := []rune(cmd); len(r) > maxRunes {
+		cmd = strings.TrimSpace(string(r[:maxRunes])) + " …"
+	}
+	return cmd
+}
+
 func extractTextFromStreamJSON(line string) string {
 	line = sanitizeStreamLine(line)
 	if line == "" {
@@ -730,7 +745,7 @@ func extractTextFromStreamJSON(line string) string {
 					if toolName == "Bash" || toolName == "bash" || toolName == "execute_bash" {
 						if input, ok := contentItem["input"].(map[string]any); ok {
 							if cmd, ok := input["command"].(string); ok {
-								texts = append(texts, fmt.Sprintf("[EXEC] %s", cmd))
+								texts = append(texts, fmt.Sprintf("[EXEC] %s", summarizeCommand(cmd)))
 							}
 						}
 					}

--- a/cmd/awkit/kickoff_test.go
+++ b/cmd/awkit/kickoff_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/silver2dream/ai-workflow-kit/internal/analyzer"
@@ -143,6 +144,25 @@ func TestSanitizeStreamLine(t *testing.T) {
 				t.Errorf("sanitizeStreamLine(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSummarizeCommand(t *testing.T) {
+	// Short single-line command is unchanged.
+	if got := summarizeCommand("awkit analyze-next --json"); got != "awkit analyze-next --json" {
+		t.Errorf("short cmd changed: %q", got)
+	}
+	// A multi-line heredoc collapses to its first line; the body must not leak.
+	got := summarizeCommand("cat > /tmp/x.md << 'EOF'\n### huge review body\nline2\nEOF")
+	if !strings.HasPrefix(got, "cat > /tmp/x.md << 'EOF'") {
+		t.Errorf("heredoc first line lost: %q", got)
+	}
+	if strings.Contains(got, "review body") || strings.Contains(got, "line2") {
+		t.Errorf("heredoc body leaked into [EXEC]: %q", got)
+	}
+	// A very long single line is truncated to bounded output.
+	if got := summarizeCommand("echo " + strings.Repeat("x", 500)); len([]rune(got)) > 210 {
+		t.Errorf("long cmd not truncated: %d runes", len([]rune(got)))
 	}
 }
 


### PR DESCRIPTION
The kickoff console prints each Bash tool_use as "[EXEC] <command>" verbatim. During PR review the Principal builds the review body with a heredoc (cat > review_body.md << 'EOF' ...hundreds of lines... EOF), so that single command dumped the entire review to the terminal — the unreadable spew seen during the review phase. Collapse the command to its first line, capped at 200 runes (rune-based so a UTF-8 char is never split), before display.