### PR TITLE
[feat] re-schedule falsely-completed tasks (issue closed, no merged PR)

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -302,7 +302,7 @@ func (a *Analyzer) Decide(ctx context.Context) (*Decision, error) {
 		}, nil
 	}
 
-	if decision := a.checkTasksFiles(); decision != nil {
+	if decision := a.checkTasksFiles(ctx); decision != nil {
 		return decision, nil
 	}
 
@@ -432,8 +432,9 @@ func (a *Analyzer) extractPRNumberForIssue(issueNumber int, issueBody string) in
 	return 0
 }
 
-// checkTasksFiles checks tasks.md files for uncompleted tasks
-func (a *Analyzer) checkTasksFiles() *Decision {
+// checkTasksFiles checks tasks.md files for uncompleted tasks, and re-schedules
+// tasks that were "falsely completed" (issue closed with no merged PR).
+func (a *Analyzer) checkTasksFiles(ctx context.Context) *Decision {
 	if a.Config == nil || len(a.Config.Specs.Active) == 0 {
 		return nil
 	}
@@ -472,18 +473,26 @@ func (a *Analyzer) checkTasksFiles() *Decision {
 
 		scanner := bufio.NewScanner(file)
 		lineNum := 0
+		var refTasks []refTask
 		for scanner.Scan() {
 			lineNum++
 			line := scanner.Text()
 
-			// Check for uncompleted task
-			if strings.HasPrefix(line, "- [ ]") && !strings.Contains(line, "<!-- Issue #") {
+			if !strings.HasPrefix(line, "- [ ]") {
+				continue
+			}
+			// A task that was never dispatched (no issue ref) is created first.
+			if !strings.Contains(line, "<!-- Issue #") {
 				file.Close()
 				return &Decision{
 					NextAction: ActionCreateTask,
 					SpecName:   spec,
 					TaskLine:   lineNum,
 				}
+			}
+			// Otherwise remember it for the false-completion check below.
+			if n := parseIssueRefNumber(line); n > 0 {
+				refTasks = append(refTasks, refTask{issue: n, line: lineNum})
 			}
 		}
 		// Check for scanner errors (e.g., I/O errors during reading)
@@ -492,8 +501,86 @@ func (a *Analyzer) checkTasksFiles() *Decision {
 			continue // Skip this spec file on read error
 		}
 		file.Close()
+
+		// Every remaining task carries an issue ref. Re-schedule any that were
+		// closed without the work actually landing — a merged PR is the proof of
+		// completion.
+		if d := a.checkFalseCompletions(ctx, spec, refTasks); d != nil {
+			return d
+		}
 	}
 
+	return nil
+}
+
+// refTask is a tasks.md task line that already carries a GitHub issue reference.
+type refTask struct {
+	issue int
+	line  int
+}
+
+// parseIssueRefNumber extracts N from a "<!-- Issue #N -->" marker on a task
+// line, or 0 when the marker is absent or malformed.
+func parseIssueRefNumber(line string) int {
+	const marker = "<!-- Issue #"
+	i := strings.Index(line, marker)
+	if i < 0 {
+		return 0
+	}
+	rest := line[i+len(marker):]
+	end := strings.IndexFunc(rest, func(r rune) bool { return r < '0' || r > '9' })
+	if end <= 0 {
+		return 0
+	}
+	n, _ := strconv.Atoi(rest[:end])
+	return n
+}
+
+// checkFalseCompletions re-schedules the first task whose issue was closed
+// without the work landing. A task is genuinely done only if a MERGED PR exists
+// for its feat/ai-issue-<n> branch; a closed issue with no merged PR (e.g. a
+// worker that produced no changes, or the codex read-only sandbox bug) is a
+// false completion — reopen the issue and dispatch a worker to actually do it.
+// Best-effort: on any GitHub API error it returns nil rather than risk
+// misclassifying a genuine completion as false.
+func (a *Analyzer) checkFalseCompletions(ctx context.Context, spec string, refTasks []refTask) *Decision {
+	if len(refTasks) == 0 {
+		return nil
+	}
+
+	taskLabel := DefaultLabels().Task
+	if a.Config != nil && a.Config.GitHub.Labels.Task != "" {
+		taskLabel = a.Config.GitHub.Labels.Task
+	}
+
+	merged, err := a.GHClient.MergedIssueBranches(ctx)
+	if err != nil {
+		return nil
+	}
+	states, err := a.GHClient.TaskIssueStates(ctx, taskLabel)
+	if err != nil {
+		return nil
+	}
+
+	for _, rt := range refTasks {
+		if merged[fmt.Sprintf("feat/ai-issue-%d", rt.issue)] {
+			continue // genuinely completed: issue -> PR -> merge
+		}
+		// No merged PR. Only re-schedule if the issue is CLOSED; an OPEN issue is
+		// still in the pipeline and is handled by the earlier steps.
+		if states[rt.issue] != "CLOSED" {
+			continue
+		}
+		fmt.Fprintf(os.Stderr,
+			"[analyzer] false completion: issue #%d (%s line %d) is closed but has no merged PR; reopening and re-dispatching\n",
+			rt.issue, spec, rt.line)
+		_ = a.GHClient.ReopenIssue(ctx, rt.issue)
+		a.updateIssueLabels(ctx, rt.issue, []string{taskLabel}, nil)
+		return &Decision{
+			NextAction:  ActionDispatchWorker,
+			IssueNumber: rt.issue,
+		}
+	}
 	return nil
 }
 

--- a/internal/analyzer/analyzer_decide_test.go
+++ b/internal/analyzer/analyzer_decide_test.go
@@ -33,6 +33,11 @@ type MockGitHubClient struct {
 	GetIssueBodyError   error
 	UpdateIssueBodyError error
 	UpdatedBodies       map[int]string // tracks UpdateIssueBody calls
+	ReopenedIssues      []int          // tracks ReopenIssue calls
+	MergedBranches      map[string]bool // head branch -> has a merged PR
+	IssueStates         map[int]string  // issue number -> OPEN/CLOSED
+	MergedBranchesError error
+	IssueStatesError    error
 }
 
 func NewMockGitHubClient() *MockGitHubClient {
@@ -46,6 +51,8 @@ func NewMockGitHubClient() *MockGitHubClient {
 		RemovedLabels:      make(map[int][]string),
 		IssueBodies:        make(map[int]string),
 		UpdatedBodies:      make(map[int]string),
+		MergedBranches:     make(map[string]bool),
+		IssueStates:        make(map[int]string),
 	}
 }
 
@@ -133,6 +140,25 @@ func (m *MockGitHubClient) UpdateIssueBody(ctx context.Context, issueNumber int,
 	m.IssueBodies[issueNumber] = body
 	m.UpdatedBodies[issueNumber] = body
 	return nil
+}
+
+func (m *MockGitHubClient) ReopenIssue(ctx context.Context, issueNumber int) error {
+	m.ReopenedIssues = append(m.ReopenedIssues, issueNumber)
+	return nil
+}
+
+func (m *MockGitHubClient) MergedIssueBranches(ctx context.Context) (map[string]bool, error) {
+	if m.MergedBranchesError != nil {
+		return nil, m.MergedBranchesError
+	}
+	return m.MergedBranches, nil
+}
+
+func (m *MockGitHubClient) TaskIssueStates(ctx context.Context, taskLabel string) (map[int]string, error) {
+	if m.IssueStatesError != nil {
+		return nil, m.IssueStatesError
+	}
+	return m.IssueStates, nil
 }
 
 // Helper function to create test analyzer with mock client

--- a/internal/analyzer/false_completion_test.go
+++ b/internal/analyzer/false_completion_test.go
@@ -1,0 +1,113 @@
+package analyzer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseIssueRefNumber(t *testing.T) {
+	cases := map[string]int{
+		"- [ ] 1. Foundation <!-- Issue #1 -->":  1,
+		"- [ ] 12. Big task <!-- Issue #123 -->": 123,
+		"- [ ] 3. No reference here":             0,
+		"- [ ] 4. Malformed <!-- Issue # -->":    0,
+	}
+	for line, want := range cases {
+		if got := parseIssueRefNumber(line); got != want {
+			t.Errorf("parseIssueRefNumber(%q) = %d, want %d", line, got, want)
+		}
+	}
+}
+
+// writeSpecTasks writes a one-task tasks.md (with an issue ref) for spec "demo".
+func writeSpecTasks(t *testing.T, tmpDir, line string) *Config {
+	t.Helper()
+	specDir := filepath.Join(tmpDir, ".ai", "specs", "demo")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(specDir, "tasks.md"), []byte(line+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &Config{}
+	cfg.Specs.BasePath = ".ai/specs"
+	cfg.Specs.Active = []string{"demo"}
+	cfg.GitHub.Labels = DefaultLabels()
+	return cfg
+}
+
+func TestCheckTasksFiles_FalseCompletion(t *testing.T) {
+	const taskLine = "- [ ] 1. Foundation <!-- Issue #1 -->"
+
+	t.Run("closed issue with no merged PR is re-scheduled", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfg := writeSpecTasks(t, tmpDir, taskLine)
+		mock := NewMockGitHubClient()
+		mock.IssueStates[1] = "CLOSED" // closed, but no merged branch recorded
+		a := newTestAnalyzer(tmpDir, cfg, mock)
+
+		d := a.checkTasksFiles(context.Background())
+		if d == nil || d.NextAction != ActionDispatchWorker || d.IssueNumber != 1 {
+			t.Fatalf("want dispatch_worker for #1, got %+v", d)
+		}
+		if len(mock.ReopenedIssues) != 1 || mock.ReopenedIssues[0] != 1 {
+			t.Errorf("issue #1 should have been reopened, got %v", mock.ReopenedIssues)
+		}
+	})
+
+	t.Run("genuinely merged task is left alone", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfg := writeSpecTasks(t, tmpDir, taskLine)
+		mock := NewMockGitHubClient()
+		mock.IssueStates[1] = "CLOSED"
+		mock.MergedBranches["feat/ai-issue-1"] = true
+		a := newTestAnalyzer(tmpDir, cfg, mock)
+
+		if d := a.checkTasksFiles(context.Background()); d != nil {
+			t.Fatalf("a merged task must not be re-scheduled, got %+v", d)
+		}
+		if len(mock.ReopenedIssues) != 0 {
+			t.Errorf("a merged task must not be reopened, got %v", mock.ReopenedIssues)
+		}
+	})
+
+	t.Run("open in-progress task is not a false completion", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfg := writeSpecTasks(t, tmpDir, taskLine)
+		mock := NewMockGitHubClient()
+		mock.IssueStates[1] = "OPEN" // still in the pipeline — handled by earlier steps
+		a := newTestAnalyzer(tmpDir, cfg, mock)
+
+		if d := a.checkTasksFiles(context.Background()); d != nil {
+			t.Fatalf("an open task must be left to earlier steps, got %+v", d)
+		}
+	})
+
+	t.Run("API error never misclassifies as false completion", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfg := writeSpecTasks(t, tmpDir, taskLine)
+		mock := NewMockGitHubClient()
+		mock.IssueStates[1] = "CLOSED"
+		mock.MergedBranchesError = fmt.Errorf("github down")
+		a := newTestAnalyzer(tmpDir, cfg, mock)
+
+		if d := a.checkTasksFiles(context.Background()); d != nil {
+			t.Fatalf("on API error the analyzer must not re-schedule, got %+v", d)
+		}
+	})
+
+	t.Run("task with no issue ref still takes create_task priority", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfg := writeSpecTasks(t, tmpDir, "- [ ] 1. Foundation (never dispatched)")
+		mock := NewMockGitHubClient()
+		a := newTestAnalyzer(tmpDir, cfg, mock)
+
+		d := a.checkTasksFiles(context.Background())
+		if d == nil || d.NextAction != ActionCreateTask {
+			t.Fatalf("want create_task for an unreferenced task, got %+v", d)
+		}
+	})
+}

--- a/internal/analyzer/github.go
+++ b/internal/analyzer/github.go
@@ -50,6 +50,9 @@ type GitHubClientInterface interface {
 	FindPRByBranch(ctx context.Context, branchName string) (int, error)
 	GetIssueBody(ctx context.Context, issueNumber int) (string, error)
 	UpdateIssueBody(ctx context.Context, issueNumber int, body string) error
+	ReopenIssue(ctx context.Context, issueNumber int) error
+	MergedIssueBranches(ctx context.Context) (map[string]bool, error)
+	TaskIssueStates(ctx context.Context, taskLabel string) (map[int]string, error)
 }
 
 // GitHubClient wraps GitHub CLI operations
@@ -269,6 +272,73 @@ func (c *GitHubClient) CloseIssue(ctx context.Context, issueNumber int) error {
 
 	_, err := ghutil.RunWithRetry(ctx, c.Retry, "gh", "issue", "close", strconv.Itoa(issueNumber))
 	return err
+}
+
+// ReopenIssue reopens a closed issue. Used to re-schedule a task whose issue was
+// closed without the work actually landing (a "false completion").
+func (c *GitHubClient) ReopenIssue(ctx context.Context, issueNumber int) error {
+	ctx, cancel := context.WithTimeout(ctx, c.Timeout)
+	defer cancel()
+
+	_, err := ghutil.RunWithRetry(ctx, c.Retry, "gh", "issue", "reopen", strconv.Itoa(issueNumber))
+	return err
+}
+
+// MergedIssueBranches returns the set of head-branch names that have a MERGED
+// PR. It lets the analyzer distinguish a genuinely-completed task (issue -> PR
+// -> merge) from a "false completion": an issue closed with no merged PR (e.g.
+// the codex read-only "success_no_changes" bug closed issues without ever
+// landing code). One API call for the whole repo.
+func (c *GitHubClient) MergedIssueBranches(ctx context.Context) (map[string]bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.Timeout)
+	defer cancel()
+
+	output, err := ghutil.RunWithRetry(ctx, c.Retry, "gh", "pr", "list",
+		"--state", "merged",
+		"--limit", "500",
+		"--json", "headRefName",
+		"--jq", ".[].headRefName")
+	if err != nil {
+		return nil, err
+	}
+
+	set := make(map[string]bool)
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if b := strings.TrimSpace(line); b != "" {
+			set[b] = true
+		}
+	}
+	return set, nil
+}
+
+// TaskIssueStates returns a map of task-issue number -> state ("OPEN"/"CLOSED")
+// for every issue carrying the task label, in one API call.
+func (c *GitHubClient) TaskIssueStates(ctx context.Context, taskLabel string) (map[int]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.Timeout)
+	defer cancel()
+
+	output, err := ghutil.RunWithRetry(ctx, c.Retry, "gh", "issue", "list",
+		"--label", taskLabel,
+		"--state", "all",
+		"--limit", "500",
+		"--json", "number,state")
+	if err != nil {
+		return nil, err
+	}
+
+	var issues []struct {
+		Number int    `json:"number"`
+		State  string `json:"state"`
+	}
+	if err := json.Unmarshal(output, &issues); err != nil {
+		return nil, err
+	}
+
+	states := make(map[int]string, len(issues))
+	for _, is := range issues {
+		states[is.Number] = strings.ToUpper(is.State)
+	}
+	return states, nil
 }
 
 // GetIssueBody reads the body of a GitHub issue

--- a/internal/analyzer/helpers_test.go
+++ b/internal/analyzer/helpers_test.go
@@ -239,7 +239,7 @@ func TestCheckTasksFiles(t *testing.T) {
 			tt.setupFiles()
 
 			a := New(tmpDir, tt.config)
-			decision := a.checkTasksFiles()
+			decision := a.checkTasksFiles(context.Background())
 
 			if tt.wantAction == "" {
 				if decision != nil {

--- a/internal/epicaudit/audit_extra_test.go
+++ b/internal/epicaudit/audit_extra_test.go
@@ -31,6 +31,13 @@ func (m *mockGHClient) AddLabel(_ context.Context, _ int, _ string) error       
 func (m *mockGHClient) IsPRMerged(_ context.Context, _ int) (bool, error)         { return false, nil }
 func (m *mockGHClient) CloseIssue(_ context.Context, _ int) error                 { return nil }
 func (m *mockGHClient) FindPRByBranch(_ context.Context, _ string) (int, error)   { return 0, nil }
+func (m *mockGHClient) ReopenIssue(_ context.Context, _ int) error                { return nil }
+func (m *mockGHClient) MergedIssueBranches(_ context.Context) (map[string]bool, error) {
+	return nil, nil
+}
+func (m *mockGHClient) TaskIssueStates(_ context.Context, _ string) (map[int]string, error) {
+	return nil, nil
+}
 func (m *mockGHClient) UpdateIssueBody(_ context.Context, _ int, _ string) error  { return nil }
 
 // compile-time check


### PR DESCRIPTION
analyze-next trusted a tasks.md issue ref plus a closed issue as "done", so a task whose issue was closed WITHOUT the work ever landing (a merged PR) was skipped forever. This is exactly what the codex read-only sandbox bug produced: issues #1-6 closed via success_no_changes — no PR, no code on main — yet the workflow believed those steps were complete and stacked new work on an empty foundation.

checkTasksFiles now verifies genuine completion: a task is done only if a MERGED PR exists for its feat/ai-issue-<n> branch. A ref'd task whose issue is CLOSED with no merged PR is a false completion — reopen the issue and dispatch a worker to actually do it. OPEN issues are left to the earlier pipeline steps; on any GitHub API error it declines to re-schedule rather than risk misclassifying a genuine completion. Two batched API calls (merged branches + task-issue states) keep it cheap regardless of task count.

New GitHubClient methods: ReopenIssue, MergedIssueBranches, TaskIssueStates. tasks_md mode only (epic mode's checkEpicProgress is a separate path).

Tests: parseIssueRefNumber + false/genuine/in-progress/api-error/create-task.