### PR TITLE
[fix] scaffold frontend tsconfig with skipLibCheck (fresh scaffold bu…

### DIFF
--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -1849,6 +1849,12 @@ func scaffoldReactFrontend(targetDir string, force, dryRun bool) (*ScaffoldResul
 		},
 		{
 			path: filepath.Join(targetDir, "tsconfig.json"),
+			// skipLibCheck is required (and is the Vite/TS official-template
+			// default): tsc type-checks the .d.ts of build tooling like vite and
+			// rollup, whose type defs legitimately use Node types and ES2023
+			// (Symbol.asyncDispose). Without it a brand-new scaffold fails `tsc`
+			// on third-party .d.ts — code the app never wrote — so `npm run build`
+			// (tsc && vite build) is red out of the box and blocks every PR.
 			content: []byte(`{
   "compilerOptions": {
     "target": "ES2022",
@@ -1857,6 +1863,7 @@ func scaffoldReactFrontend(targetDir string, force, dryRun bool) (*ScaffoldResul
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "strict": true,
+    "skipLibCheck": true,
     "noEmit": true
   },
   "include": ["src"]

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -1038,6 +1039,43 @@ func TestValidateProjectName(t *testing.T) {
 				t.Errorf("unexpected error for input %q: %v", tc.input, err)
 			}
 		})
+	}
+}
+
+// TestScaffoldReactFrontendTsconfigSkipsLibCheck guards that a freshly
+// scaffolded frontend carries skipLibCheck, so its `tsc` (npm run build) passes
+// on the .d.ts of build tooling (vite/rollup) instead of being red out of the
+// box and blocking every PR's CI. Regression for the tennis-arena scaffold.
+func TestScaffoldReactFrontendTsconfigSkipsLibCheck(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "awkit-scaffold-tsconfig-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if _, err := Scaffold(tmpDir, ScaffoldOptions{
+		Preset:      "react-go",
+		TargetDir:   tmpDir,
+		ProjectName: "test-project",
+	}); err != nil {
+		t.Fatalf("Scaffold(react-go) failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "frontend", "tsconfig.json"))
+	if err != nil {
+		t.Fatalf("read frontend tsconfig: %v", err)
+	}
+
+	var cfg struct {
+		CompilerOptions struct {
+			SkipLibCheck bool `json:"skipLibCheck"`
+		} `json:"compilerOptions"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("generated frontend tsconfig is not valid JSON: %v", err)
+	}
+	if !cfg.CompilerOptions.SkipLibCheck {
+		t.Error("frontend tsconfig must set skipLibCheck:true so a fresh scaffold's tsc passes on vite/rollup .d.ts")
 	}
 }
 


### PR DESCRIPTION
…ilds clean)

A freshly scaffolded frontend was red on `tsc` out of the box: `npm run build` (tsc && vite build) type-checks the .d.ts of the build tooling — vite's Node types and rollup's ES2023 Symbol.asyncDispose — and failed on ~30 errors inside node_modules that the app never wrote. A backend-only PR was then blocked by a frontend CI failure it had nothing to do with.

skipLibCheck:true is the Vite/TypeScript official-template default for exactly this reason: an app must not fail to compile over its build tooling's type definitions, and it does NOT weaken type-checking of the app's own code. This is a scaffold-correctness fix — CI stays a real gate (no CI bypass, no path-based skip); the scaffold just no longer ships a frontend that cannot build.

Verified: `tsc --skipLibCheck` on the generated frontend exits 0.
Test: the generated frontend tsconfig sets skipLibCheck.