### PR TITLE
[feat] self-heal integration branch missing scaffold

### DIFF
--- a/cmd/awkit/analyze_next.go
+++ b/cmd/awkit/analyze_next.go
@@ -76,6 +76,14 @@ func cmdAnalyzeNext(args []string) int {
 		}
 	}
 
+	// Self-heal structural bad states before deciding, so a repaired base is in
+	// place before any worker is dispatched. Most importantly this restores an
+	// integration branch that lost its scaffold to an early false-completion —
+	// otherwise every worker branches from an empty tree and the loop stalls.
+	// Output is confined to stderr/trace so it never corrupts the decision on
+	// stdout that the principal evals.
+	reconcileStructuralState(*stateRoot)
+
 	// Create analyzer
 	a := analyzer.New(*stateRoot, nil)
 

--- a/cmd/awkit/main.go
+++ b/cmd/awkit/main.go
@@ -127,6 +127,8 @@ func run() int {
 		return cmdSession(os.Args[2:])
 	case "analyze-next":
 		return cmdAnalyzeNext(os.Args[2:])
+	case "reconcile":
+		return cmdReconcile(os.Args[2:])
 	case "stop-workflow":
 		return cmdStopWorkflow(os.Args[2:])
 	case "prepare-review":
@@ -283,6 +285,8 @@ func cmdHelp(command string) int {
 		usageSession()
 	case "analyze-next":
 		usageAnalyzeNext()
+	case "reconcile":
+		usageReconcile()
 	case "stop-workflow":
 		usageStopWorkflow()
 	case "prepare-review":

--- a/cmd/awkit/reconcile.go
+++ b/cmd/awkit/reconcile.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/silver2dream/ai-workflow-kit/internal/kickoff"
+	"github.com/silver2dream/ai-workflow-kit/internal/selfheal"
+	"github.com/silver2dream/ai-workflow-kit/internal/trace"
+)
+
+func usageReconcile() {
+	fmt.Fprint(os.Stderr, `Reconcile a project's structural state back to a workable baseline
+
+The workflow can be left in a recoverable-but-broken shape by earlier failures —
+most commonly an integration branch that never received a repo's scaffold because
+an early task false-completed, so every worker then branches from an empty tree.
+reconcile detects such damage and self-corrects it (regenerate the missing
+scaffold on an isolated worktree, commit, and push) so the workflow keeps going
+instead of stalling.
+
+This runs automatically before every analyze-next; the command exists so operators
+can preview (--dry-run) or force a reconcile out of band.
+
+Usage:
+  awkit reconcile [options]
+
+Options:
+  --dry-run       Report what would change without pushing anything
+  --json          Output the reconcile result as JSON
+  --state-root    Override state root (default: current git root)
+  --help          Show this help
+
+Examples:
+  awkit reconcile --dry-run
+  awkit reconcile
+`)
+}
+
+func cmdReconcile(args []string) int {
+	fs := flag.NewFlagSet("reconcile", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.Usage = usageReconcile
+
+	dryRun := fs.Bool("dry-run", false, "")
+	jsonOutput := fs.Bool("json", false, "")
+	stateRoot := fs.String("state-root", "", "")
+	showHelp := fs.Bool("help", false, "")
+	showHelpShort := fs.Bool("h", false, "")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *showHelp || *showHelpShort {
+		usageReconcile()
+		return 0
+	}
+
+	if *stateRoot == "" {
+		root, err := resolveGitRoot()
+		if err != nil {
+			errorf("failed to resolve git root: %v\n", err)
+			return 1
+		}
+		*stateRoot = root
+	}
+
+	res := runScaffoldReconcile(*stateRoot, *dryRun)
+
+	if *jsonOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		// ScaffoldReconcile carries an error value that does not marshal; project
+		// it onto a serialisable view.
+		_ = enc.Encode(map[string]any{
+			"healthy": res.Healthy,
+			"missing": res.Missing,
+			"preset":  res.Preset,
+			"fixed":   res.Fixed,
+			"message": res.Message,
+			"error":   errString(res.Err),
+		})
+	} else {
+		fmt.Println(res.Message)
+	}
+
+	if res.Err != nil {
+		return 1
+	}
+	return 0
+}
+
+// runScaffoldReconcile loads the project config and runs the integration-branch
+// scaffold reconcile. Shared by the reconcile command and the automatic pass in
+// analyze-next so both behave identically.
+func runScaffoldReconcile(stateRoot string, dryRun bool) selfheal.ScaffoldReconcile {
+	cfg, err := kickoff.LoadConfig(filepath.Join(stateRoot, ".ai", "config", "workflow.yaml"))
+	if err != nil {
+		return selfheal.ScaffoldReconcile{Healthy: true, Message: fmt.Sprintf("skipped: config not loadable (%v)", err)}
+	}
+
+	repos := make([]selfheal.Repo, 0, len(cfg.Repos))
+	for _, r := range cfg.Repos {
+		repos = append(repos, selfheal.Repo{Path: r.Path, Language: r.Language})
+	}
+
+	return selfheal.ReconcileIntegrationScaffold(stateRoot, cfg.Git.IntegrationBranch, repos, dryRun)
+}
+
+// reconcileStructuralState is the automatic self-heal pass run before the
+// analyzer decides, so a repaired base is in place before any worker is
+// dispatched. It applies fixes for real (dryRun=false). All output goes to
+// stderr/trace only — never stdout — so it can't corrupt the analyze-next
+// bash/JSON that the principal evals.
+func reconcileStructuralState(stateRoot string) {
+	res := runScaffoldReconcile(stateRoot, false)
+	if res.Healthy {
+		clearReconcileNotice(stateRoot) // reset dedupe so a future relapse re-reports
+		return
+	}
+
+	level := trace.LevelInfo
+	if res.Err != nil {
+		level = trace.LevelWarn
+	}
+	trace.WriteEvent(trace.ComponentPrincipal, trace.TypeReconcile, level, trace.WithData(map[string]any{
+		"kind":    "integration_scaffold",
+		"missing": res.Missing,
+		"preset":  res.Preset,
+		"fixed":   res.Fixed,
+		"message": res.Message,
+	}))
+
+	// Print to the console only when the situation changed, so a persistent
+	// un-fixable state (e.g. a read-only token, or a preset that can't be
+	// inferred) doesn't spam a line every single loop.
+	if reconcileNoticeChanged(stateRoot, res.Message) {
+		fmt.Fprintf(os.Stderr, "[reconcile] %s\n", res.Message)
+	}
+}
+
+// reconcileNoticeChanged reports whether msg differs from the last reconcile
+// notice printed, recording msg as the new last notice.
+func reconcileNoticeChanged(stateRoot, msg string) bool {
+	path := filepath.Join(stateRoot, ".ai", "state", "reconcile.last")
+	if prev, err := os.ReadFile(path); err == nil && string(prev) == msg {
+		return false
+	}
+	_ = os.MkdirAll(filepath.Dir(path), 0755)
+	_ = os.WriteFile(path, []byte(msg), 0644)
+	return true
+}
+
+// clearReconcileNotice forgets the last notice once the state is healthy again,
+// so a relapse is reported afresh rather than suppressed by a stale match.
+func clearReconcileNotice(stateRoot string) {
+	_ = os.Remove(filepath.Join(stateRoot, ".ai", "state", "reconcile.last"))
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -49,6 +49,11 @@ type ScaffoldOptions struct {
 	ProjectName string
 	Force       bool
 	DryRun      bool
+	// SkipDeps skips post-scaffold dependency installation (e.g. `npm install`).
+	// Used by self-heal, which only needs the source scaffold committed to the
+	// integration branch — installing node_modules there would be slow, require
+	// a network, and risk committing thousands of dependency files.
+	SkipDeps bool
 }
 
 // ScaffoldResult contains scaffold operation results
@@ -1514,7 +1519,7 @@ func Scaffold(targetDir string, opts ScaffoldOptions) (*ScaffoldResult, error) {
 	// Determine scaffold type based on preset
 	switch opts.Preset {
 	case "", "generic", "node":
-		return scaffoldNode(targetDir, projectName, opts.Force, opts.DryRun)
+		return scaffoldNode(targetDir, projectName, opts.Force, opts.DryRun, opts.SkipDeps)
 	case "go":
 		return scaffoldGo(targetDir, projectName, opts.Force, opts.DryRun)
 	case "python":
@@ -1524,15 +1529,15 @@ func Scaffold(targetDir string, opts ScaffoldOptions) (*ScaffoldResult, error) {
 	case "dotnet":
 		return scaffoldDotnet(targetDir, projectName, opts.Force, opts.DryRun)
 	case "react-go":
-		return scaffoldMonorepo(targetDir, projectName, "go", "react", opts.Force, opts.DryRun)
+		return scaffoldMonorepo(targetDir, projectName, "go", "react", opts.Force, opts.DryRun, opts.SkipDeps)
 	case "react-python":
-		return scaffoldMonorepo(targetDir, projectName, "python", "react", opts.Force, opts.DryRun)
+		return scaffoldMonorepo(targetDir, projectName, "python", "react", opts.Force, opts.DryRun, opts.SkipDeps)
 	case "unity-go":
-		return scaffoldMonorepo(targetDir, projectName, "go", "unity", opts.Force, opts.DryRun)
+		return scaffoldMonorepo(targetDir, projectName, "go", "unity", opts.Force, opts.DryRun, opts.SkipDeps)
 	case "godot-go":
-		return scaffoldMonorepo(targetDir, projectName, "go", "godot", opts.Force, opts.DryRun)
+		return scaffoldMonorepo(targetDir, projectName, "go", "godot", opts.Force, opts.DryRun, opts.SkipDeps)
 	case "unreal-go":
-		return scaffoldMonorepo(targetDir, projectName, "go", "unreal", opts.Force, opts.DryRun)
+		return scaffoldMonorepo(targetDir, projectName, "go", "unreal", opts.Force, opts.DryRun, opts.SkipDeps)
 	default:
 		return result, fmt.Errorf("%w: %q", ErrUnknownPreset, opts.Preset)
 	}
@@ -1690,7 +1695,7 @@ func scaffoldDotnet(targetDir, projectName string, force, dryRun bool) (*Scaffol
 	return scaffoldFiles(files, force, dryRun, result)
 }
 
-func scaffoldNode(targetDir, projectName string, force, dryRun bool) (*ScaffoldResult, error) {
+func scaffoldNode(targetDir, projectName string, force, dryRun, skipDeps bool) (*ScaffoldResult, error) {
 	result := &ScaffoldResult{}
 
 	files := []struct {
@@ -1757,14 +1762,14 @@ describe("smoke", () => {
 	}
 
 	// Install npm dependencies if package.json was created
-	if _, statErr := os.Stat(filepath.Join(targetDir, "package.json")); statErr == nil {
+	if _, statErr := os.Stat(filepath.Join(targetDir, "package.json")); statErr == nil && !skipDeps {
 		_ = npmInstallFunc(targetDir)
 	}
 
 	return res, nil
 }
 
-func scaffoldMonorepo(targetDir, projectName, backend, frontend string, force, dryRun bool) (*ScaffoldResult, error) {
+func scaffoldMonorepo(targetDir, projectName, backend, frontend string, force, dryRun, skipDeps bool) (*ScaffoldResult, error) {
 	result := &ScaffoldResult{}
 
 	// Scaffold backend
@@ -1792,7 +1797,7 @@ func scaffoldMonorepo(targetDir, projectName, backend, frontend string, force, d
 
 	switch frontend {
 	case "react":
-		frontendResult, err = scaffoldReactFrontend(frontendDir, force, dryRun)
+		frontendResult, err = scaffoldReactFrontend(frontendDir, force, dryRun, skipDeps)
 	case "unity":
 		frontendResult, err = scaffoldUnityFrontend(frontendDir, force, dryRun)
 	case "godot":
@@ -1814,7 +1819,7 @@ func scaffoldMonorepo(targetDir, projectName, backend, frontend string, force, d
 	return result, nil
 }
 
-func scaffoldReactFrontend(targetDir string, force, dryRun bool) (*ScaffoldResult, error) {
+func scaffoldReactFrontend(targetDir string, force, dryRun, skipDeps bool) (*ScaffoldResult, error) {
 	result := &ScaffoldResult{}
 
 	files := []struct {
@@ -1945,7 +1950,7 @@ describe('smoke', () => {
 	}
 
 	// Install npm dependencies if package.json was created
-	if _, statErr := os.Stat(filepath.Join(targetDir, "package.json")); statErr == nil {
+	if _, statErr := os.Stat(filepath.Join(targetDir, "package.json")); statErr == nil && !skipDeps {
 		_ = npmInstallFunc(targetDir)
 	}
 

--- a/internal/selfheal/scaffold.go
+++ b/internal/selfheal/scaffold.go
@@ -1,0 +1,257 @@
+// Package selfheal reconciles a project's structural state back to a workable
+// baseline so the workflow can keep going instead of spinning or stalling on
+// damage left by earlier failures. It is declarative: it compares the desired
+// state (the integration branch has each repo's scaffold) to the actual state
+// and, when they diverge, corrects it — safely, idempotently, and observably.
+package selfheal
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/silver2dream/ai-workflow-kit/internal/install"
+)
+
+// Repo is the minimal repo shape selfheal needs: where the repo lives and what
+// language it is — enough to know which base file proves its scaffold exists.
+// Kept local so selfheal depends on neither analyzer nor kickoff (no import
+// cycle, callers convert their own config).
+type Repo struct {
+	Path     string
+	Language string
+}
+
+// ScaffoldReconcile is the outcome of reconciling the integration branch scaffold.
+type ScaffoldReconcile struct {
+	Healthy bool     // integration branch already had every repo's scaffold
+	Missing []string // repo paths whose scaffold is absent on the integration branch
+	Preset  string   // preset used (or inferred) for regeneration
+	Fixed   bool     // a fix was actually applied (false in dry-run)
+	Message string
+	Err     error
+}
+
+// inferPreset derives the scaffold preset from the configured repos, so an
+// existing project (whose config never recorded the preset) can still be
+// reconciled. Returns "" when the repo mix matches no known preset.
+func inferPreset(repos []Repo) string {
+	var backend, frontend string
+	for _, r := range repos {
+		switch strings.ToLower(r.Language) {
+		case "go":
+			backend = "go"
+		case "python":
+			backend = "python"
+		case "node", "react", "typescript", "javascript":
+			frontend = "react"
+		}
+	}
+	switch {
+	case frontend == "react" && backend == "go":
+		return "react-go"
+	case frontend == "react" && backend == "python":
+		return "react-python"
+	case backend == "go" && frontend == "":
+		return "go"
+	case backend == "python" && frontend == "":
+		return "python"
+	case frontend == "react" && backend == "":
+		return "node"
+	default:
+		return ""
+	}
+}
+
+// repoBaseFile is the file whose presence proves a repo's scaffold exists.
+func repoBaseFile(r Repo) string {
+	path := strings.TrimSuffix(r.Path, "/")
+	switch strings.ToLower(r.Language) {
+	case "go":
+		return join(path, "go.mod")
+	case "node", "react", "typescript", "javascript":
+		return join(path, "package.json")
+	case "python":
+		return join(path, "pyproject.toml")
+	default:
+		return ""
+	}
+}
+
+func join(dir, file string) string {
+	if dir == "" || dir == "." {
+		return file
+	}
+	return dir + "/" + file
+}
+
+// missingRepoScaffold returns the repo paths whose base file is absent on the
+// given git ref (uses forward-slash git paths, not filepath). Presence is probed
+// through lsTree, which the caller binds to the repo root, so this stays pure and
+// testable.
+func missingRepoScaffold(ref string, repos []Repo, lsTree func(ref, path string) bool) []string {
+	var missing []string
+	for _, r := range repos {
+		base := repoBaseFile(r)
+		if base == "" {
+			continue
+		}
+		if !lsTree(ref, base) {
+			missing = append(missing, r.Path)
+		}
+	}
+	return missing
+}
+
+// ReconcileIntegrationScaffold ensures the integration branch every worker
+// branches from actually contains each repo's scaffold. If a repo's scaffold is
+// missing (e.g. the first task false-completed so the scaffold never landed on
+// main, leaving every worker to branch from an empty tree), it regenerates the
+// scaffold from the current templates on an isolated worktree, commits, and
+// pushes — so the project self-corrects instead of stalling. dryRun reports the
+// plan without changing anything.
+func ReconcileIntegrationScaffold(stateRoot, integrationBranch string, repos []Repo, dryRun bool) ScaffoldReconcile {
+	if len(repos) == 0 {
+		return ScaffoldReconcile{Healthy: true, Message: "no repos configured"}
+	}
+	branch := strings.TrimSpace(integrationBranch)
+	if branch == "" {
+		return ScaffoldReconcile{Healthy: true, Message: "no integration branch configured"}
+	}
+	ref := "origin/" + branch // workers branch from the remote integration branch
+
+	lsTree := func(ref, path string) bool {
+		out, err := exec.Command("git", "-C", stateRoot, "ls-tree", ref, "--", path).Output()
+		return err == nil && strings.TrimSpace(string(out)) != ""
+	}
+	missing := missingRepoScaffold(ref, repos, lsTree)
+	if len(missing) == 0 {
+		return ScaffoldReconcile{Healthy: true, Message: fmt.Sprintf("%s has every repo's scaffold", ref)}
+	}
+
+	preset := inferPreset(repos)
+	if preset == "" {
+		return ScaffoldReconcile{
+			Missing: missing,
+			Message: fmt.Sprintf("%s is missing scaffold for %v but the preset can't be inferred; run `awkit init --preset <name>`", ref, missing),
+		}
+	}
+
+	if dryRun {
+		return ScaffoldReconcile{
+			Missing: missing,
+			Preset:  preset,
+			Message: fmt.Sprintf("would regenerate scaffold (preset %s) for %v onto %s", preset, missing, branch),
+		}
+	}
+
+	if err := applyScaffoldToBranch(stateRoot, branch, preset); err != nil {
+		return ScaffoldReconcile{Missing: missing, Preset: preset, Err: err, Message: fmt.Sprintf("failed to reconcile scaffold: %v", err)}
+	}
+	return ScaffoldReconcile{
+		Missing: missing,
+		Preset:  preset,
+		Fixed:   true,
+		Message: fmt.Sprintf("regenerated scaffold (preset %s) onto %s and pushed", preset, branch),
+	}
+}
+
+// applyScaffoldToBranch regenerates the scaffold on an isolated worktree of the
+// integration branch and pushes it, so the main working tree is never disturbed
+// and a failure leaves nothing behind.
+func applyScaffoldToBranch(stateRoot, branch, preset string) error {
+	wt, err := os.MkdirTemp("", "awkit-scaffold-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(wt)
+	defer runGit(stateRoot, "worktree", "remove", "--force", wt) // best-effort cleanup
+
+	if err := runGit(stateRoot, "fetch", "origin", branch); err != nil {
+		return fmt.Errorf("fetch %s: %w", branch, err)
+	}
+	if err := runGit(stateRoot, "worktree", "add", "--detach", wt, "origin/"+branch); err != nil {
+		return fmt.Errorf("worktree add: %w", err)
+	}
+
+	if _, err := install.Scaffold(wt, install.ScaffoldOptions{
+		Preset:      preset,
+		TargetDir:   wt,
+		ProjectName: filepath.Base(strings.TrimSuffix(stateRoot, "/")),
+		Force:       false, // never clobber existing files — only fill the gaps
+		SkipDeps:    true,  // commit source only — never install/commit node_modules
+	}); err != nil {
+		return fmt.Errorf("scaffold: %w", err)
+	}
+
+	// The scaffold's .gitignore is written by install-time setup, not Scaffold, so
+	// on a bare integration branch it can be missing. Restore it (if absent) so a
+	// worker that later runs `npm install` here can't accidentally commit
+	// dependency trees — belt-and-suspenders alongside SkipDeps above.
+	if err := ensureScaffoldGitignore(wt); err != nil {
+		return fmt.Errorf("ensure .gitignore: %w", err)
+	}
+
+	if err := runGit(wt, "add", "-A"); err != nil {
+		return fmt.Errorf("git add: %w", err)
+	}
+	// Nothing staged -> the scaffold already matched; treat as success.
+	if runGit(wt, "diff", "--cached", "--quiet") == nil {
+		return nil
+	}
+	if err := runGit(wt, "commit", "-m", "[chore] self-heal: restore integration-branch scaffold"); err != nil {
+		return fmt.Errorf("git commit: %w", err)
+	}
+	if err := runGit(wt, "push", "origin", "HEAD:"+branch); err != nil {
+		return fmt.Errorf("git push: %w", err)
+	}
+	return nil
+}
+
+// ensureScaffoldGitignore writes a minimal .gitignore covering dependency and
+// build artifacts if the worktree root has none, so the reconciled scaffold
+// never becomes a vector for committing node_modules and friends. It is a no-op
+// when a .gitignore already exists — the project's own rules win.
+func ensureScaffoldGitignore(wt string) error {
+	path := filepath.Join(wt, ".gitignore")
+	if _, err := os.Stat(path); err == nil {
+		return nil // already present — don't touch the project's choices
+	}
+	const content = `# Dependencies
+node_modules/
+.npm/
+.yarn/
+
+# Build output
+dist/
+build/
+
+# Python caches
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+
+# Logs
+*.log
+`
+	return os.WriteFile(path, []byte(content), 0644)
+}
+
+// runGit runs a git command in dir. On failure it folds git's own stderr into
+// the error so a rejected push (read-only token, non-fast-forward) is diagnosable
+// rather than a bare "exit status 1". Callers that use it as a boolean (e.g.
+// `diff --cached --quiet`) still work — they only test the error for nil.
+func runGit(dir string, args ...string) error {
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+			return fmt.Errorf("%w: %s", err, trimmed)
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/selfheal/scaffold_integration_test.go
+++ b/internal/selfheal/scaffold_integration_test.go
@@ -1,0 +1,124 @@
+package selfheal
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// gitT runs a git command in dir and fails the test on error, returning stdout.
+func gitT(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func hasOnBranch(t *testing.T, repo, ref, path string) bool {
+	t.Helper()
+	out, _ := exec.Command("git", "-C", repo, "ls-tree", ref, "--", path).Output()
+	return strings.TrimSpace(string(out)) != ""
+}
+
+// TestReconcileIntegrationScaffold_RealPush exercises the full real mechanic —
+// isolated worktree, scaffold regeneration, commit, and push — against a local
+// bare remote, so it proves the self-heal actually repairs an integration branch
+// that lost its scaffold (the tennis-arena "empty main" corruption) without ever
+// touching a real remote. It also asserts idempotency: a second run is a healthy
+// no-op, which is what makes it safe to run every analyze-next loop.
+func TestReconcileIntegrationScaffold_RealPush(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	root := t.TempDir()
+	bare := filepath.Join(root, "origin.git")
+	work := filepath.Join(root, "work")
+
+	// A bare "origin" and a clone that has a main branch WITHOUT any repo
+	// scaffold — exactly the shape left behind when the first task
+	// false-completes and the scaffold never lands on the integration branch.
+	gitT(t, root, "init", "--bare", "-b", "main", bare)
+	gitT(t, root, "clone", bare, work)
+	gitT(t, work, "config", "user.email", "selfheal-test@example.com")
+	gitT(t, work, "config", "user.name", "Selfheal Test")
+	gitT(t, work, "config", "commit.gpgsign", "false")
+
+	writeFile(t, filepath.Join(work, "README.md"), "# proj\n")
+	gitT(t, work, "add", "-A")
+	gitT(t, work, "commit", "-m", "init without scaffold")
+	gitT(t, work, "branch", "-M", "main")
+	gitT(t, work, "push", "origin", "main")
+
+	repos := []Repo{
+		{Path: "backend/", Language: "go"},
+		{Path: "frontend/", Language: "node"},
+	}
+
+	// Sanity: the corruption is present on origin/main.
+	for _, base := range []string{"backend/go.mod", "frontend/package.json"} {
+		if hasOnBranch(t, work, "origin/main", base) {
+			t.Fatalf("precondition failed: %s already on origin/main", base)
+		}
+	}
+
+	// First reconcile must actually fix and push.
+	res := ReconcileIntegrationScaffold(work, "main", repos, false)
+	if res.Err != nil {
+		t.Fatalf("reconcile failed: %v (%s)", res.Err, res.Message)
+	}
+	if !res.Fixed {
+		t.Fatalf("expected a fix to be applied, got %+v", res)
+	}
+
+	// The scaffold base files must now exist on origin/main. The push happened
+	// from a linked worktree, which shares this repo's remote-tracking refs, so
+	// origin/main here reflects the pushed state.
+	for _, base := range []string{"backend/go.mod", "frontend/package.json"} {
+		if !hasOnBranch(t, work, "origin/main", base) {
+			t.Errorf("after reconcile, origin/main still missing %s", base)
+		}
+	}
+
+	// It must NOT have committed dependency trees. Regressing this (running
+	// `npm install` and `git add -A` with no .gitignore) would dump thousands of
+	// node_modules files onto the integration branch.
+	tree := gitT(t, work, "ls-tree", "-r", "--name-only", "origin/main")
+	if strings.Contains(tree, "node_modules/") {
+		t.Errorf("reconcile committed node_modules to origin/main:\n%s", tree)
+	}
+	// And it must have restored a .gitignore so a later worker can't leak deps.
+	if !hasOnBranch(t, work, "origin/main", ".gitignore") {
+		t.Errorf("reconcile did not restore a .gitignore on origin/main")
+	}
+
+	// The main working tree must be untouched — the fix ran on an isolated
+	// worktree, so `work` should have no stray files or dirty state.
+	if status := gitT(t, work, "status", "--porcelain"); status != "" {
+		t.Errorf("main working tree was disturbed by reconcile: %q", status)
+	}
+	if hasOnBranch(t, work, "HEAD", "backend/go.mod") {
+		t.Errorf("reconcile leaked scaffold into the checked-out branch")
+	}
+
+	// Second reconcile is a healthy no-op — safe to run every loop.
+	res2 := ReconcileIntegrationScaffold(work, "main", repos, false)
+	if res2.Err != nil {
+		t.Fatalf("second reconcile errored: %v", res2.Err)
+	}
+	if !res2.Healthy || res2.Fixed {
+		t.Errorf("second reconcile should be a healthy no-op, got %+v", res2)
+	}
+}

--- a/internal/selfheal/scaffold_test.go
+++ b/internal/selfheal/scaffold_test.go
@@ -1,0 +1,69 @@
+package selfheal
+
+import (
+	"testing"
+)
+
+func TestInferPreset(t *testing.T) {
+	cases := []struct {
+		name  string
+		repos []Repo
+		want  string
+	}{
+		{"react-go", []Repo{{Language: "go"}, {Language: "node"}}, "react-go"},
+		{"react-python", []Repo{{Language: "python"}, {Language: "node"}}, "react-python"},
+		{"go only", []Repo{{Language: "go"}}, "go"},
+		{"node only", []Repo{{Language: "node"}}, "node"},
+		{"unknown", []Repo{{Language: "rust"}}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := inferPreset(tc.repos); got != tc.want {
+				t.Errorf("inferPreset = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRepoBaseFile(t *testing.T) {
+	cases := map[string]Repo{
+		"backend/go.mod":         {Path: "backend/", Language: "go"},
+		"frontend/package.json":  {Path: "frontend/", Language: "node"},
+		"backend/pyproject.toml": {Path: "backend/", Language: "python"},
+		"go.mod":                 {Path: ".", Language: "go"},
+	}
+	for want, repo := range cases {
+		if got := repoBaseFile(repo); got != want {
+			t.Errorf("repoBaseFile(%+v) = %q, want %q", repo, got, want)
+		}
+	}
+	if got := repoBaseFile(Repo{Path: "x", Language: "rust"}); got != "" {
+		t.Errorf("unknown language should yield no base file, got %q", got)
+	}
+}
+
+func TestMissingRepoScaffold(t *testing.T) {
+	repos := []Repo{
+		{Path: "backend/", Language: "go"},
+		{Path: "frontend/", Language: "node"},
+	}
+
+	// Only backend present -> frontend missing.
+	present := map[string]bool{"backend/go.mod": true}
+	got := missingRepoScaffold("origin/main", repos, func(_, p string) bool { return present[p] })
+	if len(got) != 1 || got[0] != "frontend/" {
+		t.Errorf("want [frontend/], got %v", got)
+	}
+
+	// Nothing present -> both missing (this is the tennis-arena "empty main" case).
+	got = missingRepoScaffold("origin/main", repos, func(_, _ string) bool { return false })
+	if len(got) != 2 {
+		t.Errorf("want both repos missing, got %v", got)
+	}
+
+	// Everything present -> healthy.
+	got = missingRepoScaffold("origin/main", repos, func(_, _ string) bool { return true })
+	if len(got) != 0 {
+		t.Errorf("want nothing missing, got %v", got)
+	}
+}

--- a/internal/trace/event.go
+++ b/internal/trace/event.go
@@ -62,6 +62,7 @@ const (
 
 	// Workflow events
 	TypeWorkflowStop = "workflow_stop"
+	TypeReconcile    = "reconcile" // self-heal reconciled a structural bad state
 
 	// Worker retry
 	TypeWorkerRetry = "worker_retry"


### PR DESCRIPTION
## Problem
A project whose first task false-completes never lands its scaffold on the integration branch. Every subsequent worker then branches from an empty tree and the workflow stalls — the exact state the `awkit-example-tennis` repo is stuck in (its `origin/main` has `.ai/` but no `backend/go.mod` or `frontend/package.json`). Today the only recovery is starting a new project.

## Change
A declarative reconcile (`internal/selfheal`) that detects the divergence and self-corrects it, so the tool keeps going instead of forcing a restart:

- **Detect**: compare desired (integration branch carries each repo's scaffold) vs actual (`git ls-tree origin/<branch>`).
- **Correct**: when a repo's base file is absent, regenerate the scaffold on an **isolated worktree**, commit, and push. `Force:false` (never clobbers), fast-forward-only push, the main working tree is never touched, and a failure leaves nothing behind.
- **Idempotent + observable**: a healthy branch is a no-op; every action emits a `reconcile` trace event; console notices are deduped so a persistent un-fixable state can't spam the loop.

Supporting changes:
- `install.Scaffold` gains `SkipDeps` so self-heal commits **source only** — no `npm install`, hence no network dependency and no `node_modules` pushed to the branch. A `.gitignore` is restored as belt-and-suspenders.
- `awkit reconcile [--dry-run]` for operators; the same pass runs automatically before every `analyze-next` (stderr/trace only, so it never corrupts the decision stdout the principal evals).

## Verification
- Dry-run against the real corrupted `tennis-arena` `origin/main`: reports the exact fix (`preset react-go`, missing `[backend/ frontend/]`) and is provably inert.
- Hermetic real-push integration test against a local bare remote: repairs the branch, commits **no** `node_modules`, restores `.gitignore`, leaves the main tree clean, and is a healthy no-op on re-run.
- `go build ./...`, `go test ./...`, and `GOOS=linux go vet ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)