### PR TITLE
[fix] reconcile: stop authoring a .gitignore (conflict vector)

### DIFF
--- a/internal/selfheal/scaffold.go
+++ b/internal/selfheal/scaffold.go
@@ -176,6 +176,13 @@ func applyScaffoldToBranch(stateRoot, branch, preset string) error {
 		return fmt.Errorf("worktree add: %w", err)
 	}
 
+	// SkipDeps: commit the source scaffold only. No npm install runs, so no
+	// node_modules can exist to be committed — which is also why we deliberately
+	// do NOT write our own .gitignore here. A .gitignore that differs even
+	// slightly from the one `awkit init` commits becomes an add/add conflict
+	// against any in-flight scaffold PR (this is exactly what stalled
+	// tennis-arena's PR #8). The .gitignore is init's concern; reconcile restores
+	// only what's needed to unblock workers branching from the integration branch.
 	if _, err := install.Scaffold(wt, install.ScaffoldOptions{
 		Preset:      preset,
 		TargetDir:   wt,
@@ -184,14 +191,6 @@ func applyScaffoldToBranch(stateRoot, branch, preset string) error {
 		SkipDeps:    true,  // commit source only — never install/commit node_modules
 	}); err != nil {
 		return fmt.Errorf("scaffold: %w", err)
-	}
-
-	// The scaffold's .gitignore is written by install-time setup, not Scaffold, so
-	// on a bare integration branch it can be missing. Restore it (if absent) so a
-	// worker that later runs `npm install` here can't accidentally commit
-	// dependency trees — belt-and-suspenders alongside SkipDeps above.
-	if err := ensureScaffoldGitignore(wt); err != nil {
-		return fmt.Errorf("ensure .gitignore: %w", err)
 	}
 
 	if err := runGit(wt, "add", "-A"); err != nil {
@@ -208,36 +207,6 @@ func applyScaffoldToBranch(stateRoot, branch, preset string) error {
 		return fmt.Errorf("git push: %w", err)
 	}
 	return nil
-}
-
-// ensureScaffoldGitignore writes a minimal .gitignore covering dependency and
-// build artifacts if the worktree root has none, so the reconciled scaffold
-// never becomes a vector for committing node_modules and friends. It is a no-op
-// when a .gitignore already exists — the project's own rules win.
-func ensureScaffoldGitignore(wt string) error {
-	path := filepath.Join(wt, ".gitignore")
-	if _, err := os.Stat(path); err == nil {
-		return nil // already present — don't touch the project's choices
-	}
-	const content = `# Dependencies
-node_modules/
-.npm/
-.yarn/
-
-# Build output
-dist/
-build/
-
-# Python caches
-__pycache__/
-*.pyc
-*.pyo
-.pytest_cache/
-
-# Logs
-*.log
-`
-	return os.WriteFile(path, []byte(content), 0644)
 }
 
 // runGit runs a git command in dir. On failure it folds git's own stderr into

--- a/internal/selfheal/scaffold_integration_test.go
+++ b/internal/selfheal/scaffold_integration_test.go
@@ -92,16 +92,19 @@ func TestReconcileIntegrationScaffold_RealPush(t *testing.T) {
 		}
 	}
 
-	// It must NOT have committed dependency trees. Regressing this (running
-	// `npm install` and `git add -A` with no .gitignore) would dump thousands of
-	// node_modules files onto the integration branch.
+	// It must NOT have committed dependency trees. SkipDeps means npm install
+	// never runs, so no node_modules can exist to be staged; regressing that
+	// would dump thousands of files onto the integration branch.
 	tree := gitT(t, work, "ls-tree", "-r", "--name-only", "origin/main")
 	if strings.Contains(tree, "node_modules/") {
 		t.Errorf("reconcile committed node_modules to origin/main:\n%s", tree)
 	}
-	// And it must have restored a .gitignore so a later worker can't leak deps.
-	if !hasOnBranch(t, work, "origin/main", ".gitignore") {
-		t.Errorf("reconcile did not restore a .gitignore on origin/main")
+	// It must NOT write its own .gitignore: a .gitignore that differs from the one
+	// `awkit init` commits becomes an add/add conflict against an in-flight
+	// scaffold PR (the tennis-arena PR #8 stall). The reconcile restores source
+	// scaffold only; .gitignore is init's concern.
+	if hasOnBranch(t, work, "origin/main", ".gitignore") {
+		t.Errorf("reconcile should not author a .gitignore (conflict vector), but one is on origin/main")
 	}
 
 	// The main working tree must be untouched — the fix ran on an isolated


### PR DESCRIPTION
## Problem
The self-heal reconcile (shipped in v0.14.5) wrote its own minimal `.gitignore` onto the integration branch via `ensureScaffoldGitignore`. When an in-flight scaffold PR also adds a `.gitignore` — `awkit init` writes a fuller, marker-based one — the two differ and git raises an **add/add conflict**.

This is exactly what flipped the tennis-arena example's PR #8 to `CONFLICTING`: the reconcile pushed scaffold (incl. a 17-line `.gitignore`) to `main`, PR #8 carried init's 22-line `.gitignore`, and the principal reviewed the PR successfully but then couldn't merge it → escalated → stopped.

## Fix
Remove the `.gitignore` authoring entirely. `SkipDeps` already guarantees no `npm install` runs, so no `node_modules` can exist to be committed — the belt-and-suspenders `.gitignore` was pure downside. The reconcile restores **source scaffold only**; `.gitignore` is `awkit init`'s concern.

## Verification
- `go build ./...`, `go test ./internal/selfheal/ ./internal/install/` green.
- Integration test updated: asserts the reconcile does **not** author a `.gitignore` (the conflict vector), while still asserting no `node_modules` is committed.

## Note
This is a follow-up to #231. For a normal stalled project (first task false-completed → empty integration branch, no competing PR) the reconcile was already clean; this conflict only arises when an in-flight PR redundantly re-adds the scaffold, as in the deeply-corrupted tennis-arena legacy state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)