### PR TITLE
[fix] analyze-next: auto-resolve a conflicting pr-ready PR instead of stalling

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -116,6 +116,41 @@ func (a *Analyzer) Decide(ctx context.Context) (*Decision, error) {
 		prNumber := a.extractPRNumberForIssue(issue.Number, issue.Body)
 
 		if prNumber > 0 {
+			// A pr-ready PR that conflicts with its base can't be merged, so
+			// reviewing it just stalls the loop (the reviewer approves, the merge
+			// fails, the run escalates). Route it to automatic conflict resolution
+			// instead: dispatch_worker with a conflict merge-issue rebases the PR
+			// branch onto its base (and escalates to conflict-resolver if the
+			// worker can't). Only a definitive CONFLICTING is actionable — a
+			// transient UNKNOWN or an API error falls through to normal review.
+			// Bounded by an attempt counter so a genuinely unresolvable conflict
+			// escalates to a human rather than looping forever.
+			if status, mErr := a.GHClient.PRMergeable(ctx, prNumber); mErr == nil && status == "CONFLICTING" {
+				if a.getAttempts("conflict", prNumber) >= a.maxReviewAttempts() {
+					a.updateIssueLabels(ctx, issue.Number, []string{labels.NeedsHumanReview}, []string{labels.PRReady})
+					return &Decision{
+						NextAction:  ActionNone,
+						IssueNumber: issue.Number,
+						PRNumber:    prNumber,
+						ExitReason:  ReasonNeedsHumanReview,
+					}, nil
+				}
+				if err := a.incrementAttempts("conflict", prNumber); err != nil {
+					a.updateIssueLabels(ctx, issue.Number, []string{labels.NeedsHumanReview}, []string{labels.PRReady})
+					return &Decision{
+						NextAction:  ActionNone,
+						IssueNumber: issue.Number,
+						PRNumber:    prNumber,
+						ExitReason:  ReasonNeedsHumanReview,
+					}, nil
+				}
+				return &Decision{
+					NextAction:  ActionDispatchWorker,
+					IssueNumber: issue.Number,
+					PRNumber:    prNumber,
+					MergeIssue:  MergeIssueConflict,
+				}, nil
+			}
 			return &Decision{
 				NextAction:  ActionReviewPR,
 				IssueNumber: issue.Number,
@@ -721,10 +756,15 @@ func (a *Analyzer) maxReviewAttempts() int {
 	return DefaultMaxReviewAttempts
 }
 
-// getReviewAttempts returns the number of review attempts for a PR
-func (a *Analyzer) getReviewAttempts(prNumber int) int {
-	attemptFile := filepath.Join(a.StateRoot, ".ai", "state", "attempts", "review-pr-"+strconv.Itoa(prNumber))
-	data, err := os.ReadFile(attemptFile)
+// attemptFile is the state file tracking how many times a bounded action (kind,
+// e.g. "review" or "conflict") has been attempted for a PR.
+func (a *Analyzer) attemptFile(kind string, prNumber int) string {
+	return filepath.Join(a.StateRoot, ".ai", "state", "attempts", kind+"-pr-"+strconv.Itoa(prNumber))
+}
+
+// getAttempts returns the recorded attempt count for (kind, PR).
+func (a *Analyzer) getAttempts(kind string, prNumber int) int {
+	data, err := os.ReadFile(a.attemptFile(kind, prNumber))
 	if err != nil {
 		return 0
 	}
@@ -732,18 +772,27 @@ func (a *Analyzer) getReviewAttempts(prNumber int) int {
 	return count
 }
 
-// incrementReviewAttempts increments the review attempt count for a PR
-// Returns error if the attempt count cannot be persisted (which could cause infinite retry loops)
-func (a *Analyzer) incrementReviewAttempts(prNumber int) error {
-	attemptFile := filepath.Join(a.StateRoot, ".ai", "state", "attempts", "review-pr-"+strconv.Itoa(prNumber))
-
-	count := a.getReviewAttempts(prNumber) + 1
-	// Use atomic write to prevent corruption
-	if err := writeFileAtomic(attemptFile, []byte(strconv.Itoa(count)), 0644); err != nil {
-		fmt.Fprintf(os.Stderr, "[analyzer] error: failed to persist review attempt count for PR #%d: %v\n", prNumber, err)
+// incrementAttempts increments the attempt count for (kind, PR). Returns an error
+// if it cannot be persisted, so the caller can escalate rather than risk an
+// unbounded retry loop.
+func (a *Analyzer) incrementAttempts(kind string, prNumber int) error {
+	count := a.getAttempts(kind, prNumber) + 1
+	if err := writeFileAtomic(a.attemptFile(kind, prNumber), []byte(strconv.Itoa(count)), 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "[analyzer] error: failed to persist %s attempt count for PR #%d: %v\n", kind, prNumber, err)
 		return err
 	}
 	return nil
+}
+
+// getReviewAttempts returns the number of review attempts for a PR
+func (a *Analyzer) getReviewAttempts(prNumber int) int {
+	return a.getAttempts("review", prNumber)
+}
+
+// incrementReviewAttempts increments the review attempt count for a PR
+// Returns error if the attempt count cannot be persisted (which could cause infinite retry loops)
+func (a *Analyzer) incrementReviewAttempts(prNumber int) error {
+	return a.incrementAttempts("review", prNumber)
 }
 
 // updateIssueLabels is a helper that logs warnings if label operations fail.

--- a/internal/analyzer/analyzer_decide_test.go
+++ b/internal/analyzer/analyzer_decide_test.go
@@ -20,6 +20,8 @@ type MockGitHubClient struct {
 	OpenIssueCount      int
 	PRMerged            map[int]bool
 	PRMergedError       map[int]error
+	PRMergeableStatus   map[int]string // PR number -> MERGEABLE/CONFLICTING/UNKNOWN
+	PRMergeableError    map[int]error
 	PRByBranch          map[string]int // branch name -> PR number
 	ClosedIssues        []int
 	AddedLabels         map[int][]string
@@ -46,6 +48,8 @@ func NewMockGitHubClient() *MockGitHubClient {
 		IssuesByLabelError: make(map[string]error),
 		PRMerged:           make(map[int]bool),
 		PRMergedError:      make(map[int]error),
+		PRMergeableStatus:  make(map[int]string),
+		PRMergeableError:   make(map[int]error),
 		PRByBranch:         make(map[string]int),
 		AddedLabels:        make(map[int][]string),
 		RemovedLabels:      make(map[int][]string),
@@ -105,6 +109,16 @@ func (m *MockGitHubClient) IsPRMerged(ctx context.Context, prNumber int) (bool, 
 		return false, err
 	}
 	return m.PRMerged[prNumber], nil
+}
+
+func (m *MockGitHubClient) PRMergeable(ctx context.Context, prNumber int) (string, error) {
+	if err, ok := m.PRMergeableError[prNumber]; ok && err != nil {
+		return "", err
+	}
+	if status, ok := m.PRMergeableStatus[prNumber]; ok {
+		return status, nil
+	}
+	return "MERGEABLE", nil // default: a PR is mergeable unless a test says otherwise
 }
 
 func (m *MockGitHubClient) CloseIssue(ctx context.Context, issueNumber int) error {
@@ -293,6 +307,71 @@ func TestDecide_PRReadyWithPRNumber(t *testing.T) {
 	}
 	if decision.PRNumber != 100 {
 		t.Errorf("PRNumber = %d, want 100", decision.PRNumber)
+	}
+}
+
+// TestDecide_PRReadyConflicting_RoutesToConflictResolution is the regression for
+// the tennis-arena stall: a pr-ready PR that conflicts with its base must be
+// routed to automatic conflict resolution (dispatch_worker + conflict), not sent
+// to review where the merge fails and the run escalates/stops.
+func TestDecide_PRReadyConflicting_RoutesToConflictResolution(t *testing.T) {
+	tmpDir := t.TempDir()
+	mockClient := NewMockGitHubClient()
+	config := defaultTestConfig()
+
+	mockClient.IssuesByLabel[config.GitHub.Labels.PRReady] = []Issue{
+		{Number: 10, Body: "PR ready - see https://github.com/owner/repo/pull/100"},
+	}
+	mockClient.PRMergeableStatus[100] = "CONFLICTING"
+
+	a := newTestAnalyzer(tmpDir, config, mockClient)
+	decision, err := a.Decide(context.Background())
+	if err != nil {
+		t.Fatalf("Decide() error = %v", err)
+	}
+	if decision.NextAction != ActionDispatchWorker {
+		t.Errorf("NextAction = %q, want %q (auto-resolve, not review)", decision.NextAction, ActionDispatchWorker)
+	}
+	if decision.MergeIssue != MergeIssueConflict {
+		t.Errorf("MergeIssue = %q, want %q", decision.MergeIssue, MergeIssueConflict)
+	}
+	if decision.PRNumber != 100 {
+		t.Errorf("PRNumber = %d, want 100", decision.PRNumber)
+	}
+}
+
+// TestDecide_PRReadyConflicting_EscalatesAfterMaxAttempts ensures the auto-resolve
+// path is bounded: a genuinely unresolvable conflict must escalate to a human
+// instead of dispatching forever (the class of bug that burned 50 sessions).
+func TestDecide_PRReadyConflicting_EscalatesAfterMaxAttempts(t *testing.T) {
+	tmpDir := t.TempDir()
+	mockClient := NewMockGitHubClient()
+	config := defaultTestConfig()
+
+	mockClient.IssuesByLabel[config.GitHub.Labels.PRReady] = []Issue{
+		{Number: 10, Body: "PR ready - see https://github.com/owner/repo/pull/100"},
+	}
+	mockClient.PRMergeableStatus[100] = "CONFLICTING"
+
+	a := newTestAnalyzer(tmpDir, config, mockClient)
+	max := a.maxReviewAttempts()
+
+	for i := range max {
+		d, err := a.Decide(context.Background())
+		if err != nil {
+			t.Fatalf("attempt %d: Decide() error = %v", i, err)
+		}
+		if d.NextAction != ActionDispatchWorker || d.MergeIssue != MergeIssueConflict {
+			t.Fatalf("attempt %d: got %q/%q, want dispatch_worker/conflict", i, d.NextAction, d.MergeIssue)
+		}
+	}
+
+	d, err := a.Decide(context.Background())
+	if err != nil {
+		t.Fatalf("Decide() error = %v", err)
+	}
+	if d.NextAction != ActionNone || d.ExitReason != ReasonNeedsHumanReview {
+		t.Errorf("after %d attempts, got %q/%q, want none/needs_human_review", max, d.NextAction, d.ExitReason)
 	}
 }
 

--- a/internal/analyzer/github.go
+++ b/internal/analyzer/github.go
@@ -46,6 +46,7 @@ type GitHubClientInterface interface {
 	RemoveLabel(ctx context.Context, issueNumber int, label string) error
 	AddLabel(ctx context.Context, issueNumber int, label string) error
 	IsPRMerged(ctx context.Context, prNumber int) (bool, error)
+	PRMergeable(ctx context.Context, prNumber int) (string, error)
 	CloseIssue(ctx context.Context, issueNumber int) error
 	FindPRByBranch(ctx context.Context, branchName string) (int, error)
 	GetIssueBody(ctx context.Context, issueNumber int) (string, error)
@@ -234,6 +235,37 @@ func (c *GitHubClient) IsPRMerged(ctx context.Context, prNumber int) (bool, erro
 	}
 
 	return pr.State == "MERGED" || pr.MergedAt != "", nil
+}
+
+// PRMergeable reports GitHub's merge status for a PR: "MERGEABLE", "CONFLICTING",
+// or "UNKNOWN". GitHub computes mergeability asynchronously, so immediately after
+// a push it answers UNKNOWN; we poll briefly to let it settle before returning
+// UNKNOWN. Callers treat only a definitive "CONFLICTING" as actionable, so a
+// transient UNKNOWN (or an API error) fails open to the normal review path.
+func (c *GitHubClient) PRMergeable(ctx context.Context, prNumber int) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.Timeout)
+	defer cancel()
+
+	for attempt := 0; attempt < 3; attempt++ {
+		output, err := ghutil.RunWithRetry(ctx, c.Retry, "gh", "pr", "view",
+			strconv.Itoa(prNumber),
+			"--json", "mergeable",
+			"--jq", ".mergeable")
+		if err != nil {
+			return "", err
+		}
+		status := strings.TrimSpace(string(output))
+		if status != "" && status != "UNKNOWN" {
+			return status, nil
+		}
+		// UNKNOWN: GitHub hasn't finished computing mergeability yet. Wait and retry.
+		select {
+		case <-ctx.Done():
+			return "UNKNOWN", nil
+		case <-time.After(1 * time.Second):
+		}
+	}
+	return "UNKNOWN", nil
 }
 
 // FindPRByBranch finds an open PR by head branch name and returns its number

--- a/internal/epicaudit/audit_extra_test.go
+++ b/internal/epicaudit/audit_extra_test.go
@@ -29,6 +29,7 @@ func (m *mockGHClient) CountOpenIssues(_ context.Context, _ string) (int, error)
 func (m *mockGHClient) RemoveLabel(_ context.Context, _ int, _ string) error      { return nil }
 func (m *mockGHClient) AddLabel(_ context.Context, _ int, _ string) error         { return nil }
 func (m *mockGHClient) IsPRMerged(_ context.Context, _ int) (bool, error)         { return false, nil }
+func (m *mockGHClient) PRMergeable(_ context.Context, _ int) (string, error)      { return "MERGEABLE", nil }
 func (m *mockGHClient) CloseIssue(_ context.Context, _ int) error                 { return nil }
 func (m *mockGHClient) FindPRByBranch(_ context.Context, _ string) (int, error)   { return 0, nil }
 func (m *mockGHClient) ReopenIssue(_ context.Context, _ int) error                { return nil }


### PR DESCRIPTION
## Problem
When a `pr-ready` PR conflicts with its base, AWK reviewed it anyway — the reviewer approved, the merge failed, and the principal **escalated and stopped**. This is what halted the tennis-arena example: the self-heal reconcile pushed scaffold to `main`, PR #8 redundantly re-added it (differing `.gitignore`/`tsconfig`), so PR #8 went `CONFLICTING`, and the run escalated instead of self-healing.

The tool already had every piece needed to fix this automatically — the `merge-conflict` routing (Step 2.5), the worker rebase instructions in `dispatch.go`, and the `conflict-resolver` agent — but **nothing detected the conflict at the pr-ready stage**, so it never entered that path.

## Change
`analyze-next` now checks a pr-ready PR's mergeability before routing to review:

- **CONFLICTING** → `dispatch_worker` + `conflict` merge-issue → the worker rebases the PR branch onto its base (`git rebase origin/<base>`), escalating to the `conflict-resolver` agent if it can't. Next loop the PR is `MERGEABLE` → review → merge. **No user intervention.**
- **MERGEABLE / UNKNOWN / API error** → normal review. GitHub computes mergeability asynchronously, so a transient `UNKNOWN` (or any error) fails open to review rather than blocking.
- **Bounded**: a per-PR conflict-attempt counter (reusing the review-attempt mechanism) escalates to `needs-human-review` after N tries, so a genuinely unresolvable conflict can't loop — the 50-session-burn failure mode.

Adds `GitHubClientInterface.PRMergeable` (`gh pr view --json mergeable`, polling past the async `UNKNOWN`) and updates both mocks.

## Verification
- New tests: `TestDecide_PRReadyConflicting_RoutesToConflictResolution` (CONFLICTING → dispatch_worker/conflict) and `TestDecide_PRReadyConflicting_EscalatesAfterMaxAttempts` (bounded escalation).
- `go build ./...`, `go test ./...`, `GOOS=linux go vet ./...` all green.

## Result for the user
A broken project no longer needs manual `git` surgery: AWK detects the conflict, rebases/resolves it in the loop, and continues — the self-heal behavior requested. Combined with #233 (reconcile no longer authors a conflicting `.gitignore`), the common case never conflicts in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)