### PR TITLE
[fix] gate main pushes in CI + repair stale preflight integration fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: ["feat/example", "develop"]
+    branches: ["feat/example", "develop", "main"]
   pull_request:
     branches: ["feat/example", "develop", "main"]
 
@@ -26,6 +26,18 @@ jobs:
 
       - name: Go test (awkit)
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+
+      # Integration tests self-skip when claude CLI / gh auth are absent on
+      # the runner. Surface every skip so a green run cannot silently mean
+      # "the assertions never executed". Reporting only: failures are already
+      # gated by the main test step above.
+      - name: Integration-test skip visibility
+        run: |
+          set -o pipefail
+          status=0
+          out=$(go test ./... -run Integration -v 2>&1) || status=$?
+          echo "$out" | grep -E -- '--- (SKIP|PASS|FAIL)' || echo "no integration test results found"
+          exit $status
 
       - name: AWK evaluation (offline + strict)
         run: |

--- a/internal/kickoff/integration_test.go
+++ b/internal/kickoff/integration_test.go
@@ -48,8 +48,15 @@ func TestIntegration_PreflightToLockRelease(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// Setup config
-	configPath := filepath.Join(tmpDir, "workflow.yaml")
+	// Setup config in the production layout (<root>/.ai/config/workflow.yaml):
+	// baseDir() resolves the state root by walking three levels up from the
+	// config path, so the fixture must mirror the real structure or the
+	// spec-file checks resolve outside tmpDir.
+	configDir := filepath.Join(tmpDir, ".ai", "config")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("Failed to create config dir: %v", err)
+	}
+	configPath := filepath.Join(configDir, "workflow.yaml")
 	configContent := `version: "1.0"
 project:
   name: test-project
@@ -61,16 +68,22 @@ repos:
 git:
   integration_branch: feat/test
 specs:
-  path: .ai/specs
+  base_path: .ai/specs
+  active:
+    - testspec
 `
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("Failed to write config: %v", err)
 	}
 
-	// Create specs directory
-	specsDir := filepath.Join(tmpDir, ".ai", "specs")
-	if err := os.MkdirAll(specsDir, 0755); err != nil {
-		t.Fatalf("Failed to create specs dir: %v", err)
+	// Active specs must have a tasks.md or design.md (preflight CheckSpecFiles)
+	specDir := filepath.Join(tmpDir, ".ai", "specs", "testspec")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		t.Fatalf("Failed to create spec dir: %v", err)
+	}
+	tasksContent := "# Test Spec\n\n## Tasks\n\n- [ ] 1. Placeholder task\n"
+	if err := os.WriteFile(filepath.Join(specDir, "tasks.md"), []byte(tasksContent), 0644); err != nil {
+		t.Fatalf("Failed to write tasks.md: %v", err)
 	}
 
 	lockFile := filepath.Join(tmpDir, "kickoff.lock")

--- a/internal/kickoff/integration_test.go
+++ b/internal/kickoff/integration_test.go
@@ -90,6 +90,15 @@ specs:
 
 	// 1. Run preflight checks
 	checker := NewPreflightChecker(configPath, lockFile)
+
+	// Write access to the ambient repo is an environmental precondition, same
+	// as the gh-auth skip above: a developer whose default gh account is
+	// read-only on this repo should skip, not fail. Runs the production check
+	// itself, so no logic is duplicated here.
+	if wr := checker.CheckRepoWritePermission(); !wr.Passed {
+		t.Skipf("Skipping: %s", wr.Message)
+	}
+
 	results, err := checker.RunAll()
 	if err != nil {
 		t.Fatalf("Preflight failed: %v", err)


### PR DESCRIPTION
## Summary

Tasks 1 + 2 of `.ai/specs/awk-evolution` (R7 — CI & test robustness). Companion to #236.

### CI gates `main` (Task 1)

- `ci.yml` now runs on push to `main`: previously a merged release PR landed with **no post-merge CI at all** (push triggers covered only `feat/example` and `develop`).
- New "Integration-test skip visibility" step: integration tests self-skip when claude CLI / gh auth are absent on the runner, so a green run could silently mean "the assertions never executed". The step prints every `--- SKIP/PASS/FAIL` line for `-run Integration` tests. Reporting only — failures are still gated by the main test step; the step preserves `go test`'s exit code.

### Stale preflight integration fixture repaired (Task 2)

`TestIntegration_PreflightToLockRelease` had two environment gaps:

1. **Fixture didn't mirror production layout.** `baseDir()` resolves the state root by walking three levels up from the config path (`<root>/.ai/config/workflow.yaml`); the fixture put the config at `tmpDir/workflow.yaml`, so spec-file checks resolved *outside* tmpDir. The fixture now uses the real layout, declares `specs.active: [testspec]`, and ships a `testspec/tasks.md` — satisfying the checks added in 2db2048 the way production does, not by bypassing them.
2. **Read-only gh identity turned the test red.** The write-access preflight (correctly) fails a read-only default gh account. For this environment-dependent test that is a precondition, same as the existing gh-auth skip — the test now pre-runs the production `CheckRepoWritePermission()` check itself (no duplicated logic) and skips with the actionable message when it fails.

## Verification

- Read-only default gh identity → graceful SKIP with the preflight's guidance message (local suite green).
- `GH_TOKEN` pointed at a write-access account → test **runs fully and passes** (fixture fix proven end-to-end).
- `go build ./...`, `GOOS=linux go vet ./...`, `go test ./... -count=1` all green on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
