### PR TITLE
[feat] upgrade: align an existing project's scaffold with current templates

### DIFF
--- a/cmd/awkit/main.go
+++ b/cmd/awkit/main.go
@@ -871,6 +871,14 @@ func cmdUpgrade(args []string) int {
 			fmt.Printf("  %s\n", agentsResult.Message)
 		}
 
+		// Check scaffold alignment (dry-run)
+		scaffoldResult := upgrade.UpgradeScaffold(targetDir, true)
+		if !scaffoldResult.Skipped {
+			fmt.Println("")
+			fmt.Println(bold("Scaffold:"))
+			fmt.Printf("  %s\n", scaffoldResult.Message)
+		}
+
 		// Check config migrations (dry-run)
 		if !*skipMigrate && !*forceConfig {
 			configPath := filepath.Join(targetDir, ".ai", "config", "workflow.yaml")
@@ -937,6 +945,17 @@ func cmdUpgrade(args []string) int {
 			success("Agents installed: %s\n", agentsResult.Message)
 		} else {
 			warn("Agents install: %s\n", agentsResult.Message)
+		}
+	}
+
+	// Align scaffold with current templates (patch known defects, keep user code)
+	scaffoldResult := upgrade.UpgradeScaffold(targetDir, *dryRun)
+	if !scaffoldResult.Skipped {
+		fmt.Println("")
+		if scaffoldResult.Success {
+			success("Scaffold aligned: %s\n", scaffoldResult.Message)
+		} else {
+			warn("Scaffold align: %s\n", scaffoldResult.Message)
 		}
 	}
 

--- a/internal/upgrade/scaffold.go
+++ b/internal/upgrade/scaffold.go
@@ -1,0 +1,89 @@
+package upgrade
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ScaffoldResult represents the result of aligning an existing project's
+// scaffold with the current templates.
+type ScaffoldResult struct {
+	Success bool
+	Skipped bool
+	Changed []string
+	Message string
+}
+
+// UpgradeScaffold patches known scaffold defects in an existing project in
+// place, WITHOUT touching the user's own code — the safe middle ground that
+// `upgrade --scaffold` lacked (skip-everything vs. overwrite-everything).
+//
+// Currently it fixes a frontend tsconfig.json missing skipLibCheck: without it
+// `tsc` type-checks build tooling's .d.ts (vite/rollup) and fails, blocking CI
+// on a brand-new-but-outdated scaffold. Only the missing key is added; every
+// other setting and the file's formatting are preserved.
+func UpgradeScaffold(stateRoot string, dryRun bool) ScaffoldResult {
+	path := filepath.Join(stateRoot, "frontend", "tsconfig.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// No frontend scaffold in this project — nothing to align.
+		return ScaffoldResult{Skipped: true, Message: "no frontend/tsconfig.json to align"}
+	}
+
+	// Detect the defect via a real parse (robust to formatting differences).
+	var doc struct {
+		CompilerOptions map[string]json.RawMessage `json:"compilerOptions"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return ScaffoldResult{Message: fmt.Sprintf("frontend/tsconfig.json is not valid JSON: %v", err)}
+	}
+	if _, ok := doc.CompilerOptions["skipLibCheck"]; ok {
+		return ScaffoldResult{Skipped: true, Message: "frontend/tsconfig.json already has skipLibCheck"}
+	}
+
+	if dryRun {
+		return ScaffoldResult{Success: true, Changed: []string{"frontend/tsconfig.json"}, Message: "would add skipLibCheck to frontend/tsconfig.json"}
+	}
+
+	patched, ok := insertSkipLibCheck(string(data))
+	if !ok {
+		return ScaffoldResult{Message: "could not locate compilerOptions in frontend/tsconfig.json"}
+	}
+	if err := os.WriteFile(path, []byte(patched), 0644); err != nil {
+		return ScaffoldResult{Message: fmt.Sprintf("failed to write frontend/tsconfig.json: %v", err)}
+	}
+	return ScaffoldResult{Success: true, Changed: []string{"frontend/tsconfig.json"}, Message: "added skipLibCheck to frontend/tsconfig.json"}
+}
+
+// insertSkipLibCheck adds `"skipLibCheck": true,` immediately after the
+// compilerOptions opening brace, matching the indentation of the first existing
+// option so the file stays clean and every other line is preserved verbatim.
+func insertSkipLibCheck(content string) (string, bool) {
+	mi := strings.Index(content, "\"compilerOptions\"")
+	if mi < 0 {
+		return "", false
+	}
+	brace := strings.IndexByte(content[mi:], '{')
+	if brace < 0 {
+		return "", false
+	}
+	pos := mi + brace + 1 // just past '{'
+
+	// Indentation = leading whitespace of the next non-empty line.
+	indent := "    "
+	if nl := strings.IndexByte(content[pos:], '\n'); nl >= 0 {
+		after := content[pos+nl+1:]
+		i := 0
+		for i < len(after) && (after[i] == ' ' || after[i] == '\t') {
+			i++
+		}
+		if i > 0 {
+			indent = after[:i]
+		}
+	}
+
+	return content[:pos] + "\n" + indent + "\"skipLibCheck\": true," + content[pos:], true
+}

--- a/internal/upgrade/scaffold_test.go
+++ b/internal/upgrade/scaffold_test.go
@@ -1,0 +1,94 @@
+package upgrade
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInsertSkipLibCheck(t *testing.T) {
+	in := `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "strict": true
+  },
+  "include": ["src"]
+}`
+	out, ok := insertSkipLibCheck(in)
+	if !ok {
+		t.Fatal("should have inserted skipLibCheck")
+	}
+	if !strings.Contains(out, `"skipLibCheck": true`) {
+		t.Errorf("skipLibCheck not inserted:\n%s", out)
+	}
+	// Every original setting is preserved verbatim.
+	for _, want := range []string{`"target": "ES2022"`, `"strict": true`, `"include": ["src"]`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("lost original setting %q", want)
+		}
+	}
+	// The result is still valid JSON.
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("patched tsconfig is not valid JSON: %v", err)
+	}
+}
+
+func writeFrontendTsconfig(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	fe := filepath.Join(dir, "frontend")
+	if err := os.MkdirAll(fe, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fe, "tsconfig.json"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestUpgradeScaffold(t *testing.T) {
+	t.Run("adds missing skipLibCheck", func(t *testing.T) {
+		dir := writeFrontendTsconfig(t, `{"compilerOptions":{"target":"ES2022","strict":true}}`)
+		r := UpgradeScaffold(dir, false)
+		if r.Skipped || !r.Success {
+			t.Fatalf("expected a change, got %+v", r)
+		}
+		data, _ := os.ReadFile(filepath.Join(dir, "frontend", "tsconfig.json"))
+		var doc struct {
+			CompilerOptions map[string]any `json:"compilerOptions"`
+		}
+		if err := json.Unmarshal(data, &doc); err != nil {
+			t.Fatalf("result is not valid JSON: %v", err)
+		}
+		if doc.CompilerOptions["skipLibCheck"] != true {
+			t.Errorf("skipLibCheck not set: %v", doc.CompilerOptions)
+		}
+	})
+
+	t.Run("skips when already present", func(t *testing.T) {
+		dir := writeFrontendTsconfig(t, `{"compilerOptions":{"skipLibCheck":true}}`)
+		if r := UpgradeScaffold(dir, false); !r.Skipped {
+			t.Errorf("should skip when already present, got %+v", r)
+		}
+	})
+
+	t.Run("skips when there is no frontend", func(t *testing.T) {
+		if r := UpgradeScaffold(t.TempDir(), false); !r.Skipped {
+			t.Errorf("should skip when no frontend/tsconfig, got %+v", r)
+		}
+	})
+
+	t.Run("dry-run reports but does not write", func(t *testing.T) {
+		dir := writeFrontendTsconfig(t, `{"compilerOptions":{"target":"ES2022"}}`)
+		if r := UpgradeScaffold(dir, true); r.Skipped || !r.Success {
+			t.Fatalf("dry-run should report a pending change, got %+v", r)
+		}
+		data, _ := os.ReadFile(filepath.Join(dir, "frontend", "tsconfig.json"))
+		if strings.Contains(string(data), "skipLibCheck") {
+			t.Error("dry-run must not modify the file")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Rescued from an un-PR'd branch found during the repo cleanup audit (authored 2026-07-05, never submitted). Rebased onto current develop; all tests green.

awkit had config migrations (`migrate.Run` patches `workflow.yaml` in place) but no equivalent for scaffold files: `upgrade --scaffold` could only skip existing files or `--force`-overwrite them (wiping user code). There was no safe way to pull a scaffold **defect fix** into an existing project — which is exactly why a scaffold fix (e.g. the frontend tsconfig `skipLibCheck` fix in #227) helped only brand-new projects.

## Changes

- New `internal/upgrade` package with `UpgradeScaffold`: patches known scaffold defects **in place** without touching user code.
- First registered fix: adds a missing `skipLibCheck` to `frontend/tsconfig.json` (string-level patch preserving formatting and every other setting), so an existing project's frontend build stops failing on vite/rollup `.d.ts` after `awkit upgrade`.
- `awkit upgrade` runs it alongside the existing permissions/agents/config migrations; respects `--dry-run` (reports the pending fix without writing).
- Unit tests cover add / already-present skip / no-frontend / dry-run and the in-place string patch.

## Verification

- `go build ./...`, `GOOS=linux go vet ./...`, `go test ./internal/upgrade/ ./cmd/awkit/ -count=1` green after rebase onto develop.
- Previously verified in a real project: `upgrade --dry-run` reports the pending fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
